### PR TITLE
Temporary fix for signer import

### DIFF
--- a/packages/brain/src/modules/db/index.ts
+++ b/packages/brain/src/modules/db/index.ts
@@ -349,7 +349,7 @@ export class BrainDataBase extends LowSync<StakingBrainDb> {
   }
 
   private isValidBlsPubkey(pubkey: string): boolean {
-    if (!pubkey.match(/^0x[a-fA-F0-9]{96}$/)) return false;
+    if (!pubkey.match(/^[a-fA-F0-9]{96}$/)) return false;
     return true;
   }
 

--- a/packages/ui/src/ImportScreen.tsx
+++ b/packages/ui/src/ImportScreen.tsx
@@ -103,8 +103,10 @@ export default function ImportScreen(): JSX.Element {
           keystores: acceptedFiles.map((f) => f.file),
           passwords,
           slashing_protection: slashingFile,
-          tags: [], // TODO: Add tags
-          feeRecipients: [], // TODO  Add fee recipients
+          tags: acceptedFiles.map(() => "solo"), // TODO: Add tags
+          feeRecipients: acceptedFiles.map(
+            () => "0x0000000000000000000000000000000000000000"
+          ), // TODO  Add fee recipients
         })
       );
       setKeystoresPostError(undefined);


### PR DESCRIPTION
Keystores include public validator key without 0x (changed regex) and (tag+fee recipient) being empty were causing bad writes to DB