### PR TITLE
Fixed Nimbus validator API calls

### DIFF
--- a/packages/brain/src/modules/apiClients/index.ts
+++ b/packages/brain/src/modules/apiClients/index.ts
@@ -63,7 +63,7 @@ export class StandardApi {
         let data = "";
 
         res.on("data", (chunk) => {
-          data = chunk;
+          data += chunk;
         });
 
         res.on("end", () => {
@@ -72,7 +72,7 @@ export class StandardApi {
               try {
                 resolve(JSON.parse(data));
               } catch (e) {
-                resolve(data);
+                resolve("" + data); //Needed to parse from buffer to string
               }
             } else {
               resolve("OK");


### PR DESCRIPTION
The API calls to the validator API require the header "Content-length" for Nimbus. This header is not compatible with transfer-encoding, so it has been replaced. The calls that worked with transfer-encoding still work with the new header (already tested).