### PR TITLE
Re-render table on update dialog closed

### DIFF
--- a/packages/ui/src/components/ValidatorList/ValidatorList.tsx
+++ b/packages/ui/src/components/ValidatorList/ValidatorList.tsx
@@ -40,10 +40,13 @@ export default function ValidatorList({
     return () => clearInterval(interval);
   }, []);
 
-  // Use effect to reset the validator on delete
+  // Re-render table after delete/update validators
   useEffect(() => {
-    if (!deleteOpen) getValidators();
-  }, [deleteOpen]);
+    if (!deleteOpen && !editFeesOpen) {
+      getValidators();
+      setSelectedRows([]);
+    }
+  }, [deleteOpen, editFeesOpen]);
 
   async function getValidators() {
     try {


### PR DESCRIPTION
After delete/update dialogs are closed, the table is re-rendered and there are no rows selected