### PR TITLE
Show exit on all networks

### DIFF
--- a/packages/ui/src/components/ValidatorList/KeystoresDataGrid.tsx
+++ b/packages/ui/src/components/ValidatorList/KeystoresDataGrid.tsx
@@ -330,16 +330,14 @@ export default function KeystoresDataGrid({
             </IconButton>
           </Tooltip>
 
-          {network === "prater" && (
-            <Tooltip title="Exit validators">
-              <IconButton
-                disabled={!areRowsSelected}
-                onClick={() => setExitOpen(true)}
-              >
-                <LogoutIcon />
-              </IconButton>
-            </Tooltip>
-          )}
+          <Tooltip title="Exit validators">
+            <IconButton
+              disabled={!areRowsSelected}
+              onClick={() => setExitOpen(true)}
+            >
+              <LogoutIcon />
+            </IconButton>
+          </Tooltip>
         </div>
       </div>
       <div style={{ height: 400, width: "100%" }}>


### PR DESCRIPTION
Exit was hidden for mainnet and gnosis. Taking it back