### PR TITLE
Silent logger for importValidators

### DIFF
--- a/packages/brain/src/modules/apiServers/ui/index.ts
+++ b/packages/brain/src/modules/apiServers/ui/index.ts
@@ -25,7 +25,13 @@ export function startUiServer(uiBuildPath: string): http.Server {
       "rpc",
       async (rpcPayload: RpcPayload, callback: (res: RpcResponse) => void) => {
         logger.debug(`Received rpc call`);
-        logger.debug(rpcPayload);
+
+        // Silent logger for importValidators call (safety reasons and too much noise)
+        if (rpcPayload.method === "importValidators") {
+          logger.debug(`Call to ${rpcPayload.method} (silent logger)`);
+        } else {
+          logger.debug(rpcPayload);
+        }
 
         if (typeof callback !== "function")
           return logger.error("JSON RPC over WS req without cb");


### PR DESCRIPTION
`importValidators` was generating too much noise when being called via RPC, so it is silent now