### PR TITLE
Fix StakeHouse lib version

### DIFF
--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -23,7 +23,7 @@
     "clean:ln": "rimraf ./uiBuild"
   },
   "dependencies": {
-    "@blockswaplab/lsd-wizard": "^3.3.0",
+    "@blockswaplab/lsd-wizard": "3.3.0",
     "@stakingbrain/common": "^0.1.0",
     "ajv": "^8.12.0",
     "cors": "^2.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1094,19 +1094,26 @@
   resolved "https://registry.yarnpkg.com/@blockswaplab/lsd-protocol-abis/-/lsd-protocol-abis-1.3.0.tgz#da5f0d7a858f06832b724af63cf6f7601c139ed6"
   integrity sha512-GDTzOpEunOFdkTo3+5Vo59jTAUNCPwKvCaffBHtdddsSb2cG/QyVw5AGgDs6sH8UP6M5jrKutYllgeonx9poyw==
 
-"@blockswaplab/lsd-wizard@^3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@blockswaplab/lsd-wizard/-/lsd-wizard-3.2.3.tgz#174e600a6144329510778a9d991f177f22602e84"
-  integrity sha512-a6uuLfo67ABqazzIypfVD/AGCCBFa/gabdoiJNG0Ap6g5YRu5uvF7fE9r48xnx02dbm+ZaoJ7sFRgKqI1KJ2cQ==
+"@blockswaplab/lsd-wizard@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@blockswaplab/lsd-wizard/-/lsd-wizard-3.3.0.tgz#3573f4cb3d7031dc78f92ffcb8052105b19d3289"
+  integrity sha512-oqzWNr63lGRb4/t0JgfGRU2Cu2w8lWbvWcOaSgaJ8VAwe5yevfcP9OGTTv3izmUx9uXADoFUHOfHmWxilXvJGQ==
   dependencies:
     "@blockswaplab/lsd-protocol-abis" "1.3.0"
     "@blockswaplab/stakehouse-protocol-abis" "2.1.9"
     "@ethersproject/abstract-provider" "^5.7.0"
     "@ethersproject/contracts" "^5.7.0"
+    "@typechain/ethers-v5" "^10.2.0"
+    "@types/lodash" "^4.14.191"
+    "@types/node" "^18.15.3"
+    chai "^4.3.4"
     ethers "^5.5.3"
     graphql "^16.1.0"
     graphql-request "^3.7.0"
     lodash "^4.17.21"
+    mocha "^10.0.0"
+    typechain "^8.1.1"
+    typescript "^4.9.5"
 
 "@blockswaplab/stakehouse-protocol-abis@2.1.9":
   version "2.1.9"
@@ -3140,10 +3147,10 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
   integrity sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==
 
-"@types/lodash@^4.14.192":
-  version "4.14.192"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.192.tgz#5790406361a2852d332d41635d927f1600811285"
-  integrity sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A==
+"@types/lodash@^4.14.191":
+  version "4.14.194"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"
+  integrity sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==
 
 "@types/lowdb@^1.0.11":
   version "1.0.11"
@@ -3191,6 +3198,11 @@
   version "16.18.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.12.tgz#e3bfea80e31523fde4292a6118f19ffa24fd6f65"
   integrity sha512-vzLe5NaNMjIE3mcddFVGlAXN1LEWueUsMsOJWaT6wWMJGyljHAWHznqfnKUQWGzu7TLPrGvWdNAsvQYW+C0xtw==
+
+"@types/node@^18.15.3":
+  version "18.16.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.7.tgz#86d0ba2541f808cb78d4dc5d3e40242a349d6db8"
+  integrity sha512-MFg7ua/bRtnA1hYE3pVyWxGd/r7aMqjNOdHvlSsXV3n8iaeGKkOaPzpJh6/ovf4bEXWcojkeMJpTsq3mzXW4IQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -4511,7 +4523,7 @@ case-sensitive-paths-webpack-plugin@^2.4.0:
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz#db64066c6422eed2e08cc14b986ca43796dbc6d4"
   integrity sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==
 
-chai@^4.3.6, chai@^4.3.7:
+chai@^4.3.4, chai@^4.3.6, chai@^4.3.7:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.7.tgz#ec63f6df01829088e8bf55fca839bcd464a8ec51"
   integrity sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==
@@ -12833,15 +12845,10 @@ typescript-json-schema@^0.55.0:
     typescript "~4.8.2"
     yargs "^17.1.1"
 
-"typescript@^3 || ^4", typescript@^4.1.2, typescript@^4.9.4:
+"typescript@^3 || ^4", typescript@^4.1.2, typescript@^4.9.4, typescript@^4.9.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
-typescript@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.3.tgz#fe976f0c826a88d0a382007681cbb2da44afdedf"
-  integrity sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==
 
 typescript@~4.8.2:
   version "4.8.4"


### PR DESCRIPTION
StakeHouse version is changed from `^3.3.0` to `3.3.0`, as it is generating build errors