### PR TITLE
Fix wrong parsing in exit

### DIFF
--- a/packages/brain/src/calls/exitValidators.ts
+++ b/packages/brain/src/calls/exitValidators.ts
@@ -122,7 +122,7 @@ async function _getExitValidators(
         epoch: currentEpoch.toString(),
         validator_index: validatorIndex.index,
       },
-      signature: validatorSignature,
+      signature: validatorSignature.signature,
     });
   }
 

--- a/packages/brain/src/modules/apiClients/web3signer/index.ts
+++ b/packages/brain/src/modules/apiClients/web3signer/index.ts
@@ -7,6 +7,7 @@ import {
   Web3signerHealthcheckResponse,
   prefix0xPubkey,
   Web3SignerPostSignvoluntaryexitRequest,
+  Web3SignerPostSignvoluntaryexitResponse,
 } from "@stakingbrain/common";
 import { StandardApi } from "../index.js";
 import path from "node:path";
@@ -43,7 +44,7 @@ export class Web3SignerApi extends StandardApi {
   }: {
     signerVoluntaryExitRequest: Web3SignerPostSignvoluntaryexitRequest;
     pubkey: string;
-  }): Promise<string> {
+  }): Promise<Web3SignerPostSignvoluntaryexitResponse> {
     try {
       return await this.request(
         "POST",

--- a/packages/common/src/types/api/web3signer/types.ts
+++ b/packages/common/src/types/api/web3signer/types.ts
@@ -53,3 +53,7 @@ export interface Web3SignerPostSignvoluntaryexitRequest {
     validator_index: string;
   };
 }
+
+export interface Web3SignerPostSignvoluntaryexitResponse {
+  signature: string;
+}


### PR DESCRIPTION
Some users reported not being able to exit their prater validator and this fixes that issue. The problem was that we were parsing a signer response as a string, which was, in fact, an object like `{signature: string}`