### PR TITLE
fix: gnosis slots per epoch

### DIFF
--- a/packages/brain/src/modules/apiClients/beaconchain/index.ts
+++ b/packages/brain/src/modules/apiClients/beaconchain/index.ts
@@ -6,10 +6,12 @@ import {
   BeaconchainGenesisGetResponse,
 } from "@stakingbrain/common";
 import { StandardApi } from "../index.js";
+import { network } from "../../../index.js";
 import path from "path";
 
 export class Beaconchain extends StandardApi {
   private SLOTS_PER_EPOCH = 32;
+  private SLOTS_PER_EPOCH_GNOSIS = 16;
   private beaconchainEndpoint = "/eth/v1/beacon";
 
   /**
@@ -138,6 +140,10 @@ export class Beaconchain extends StandardApi {
    * @param slot - The slot number.
    */
   private getEpochFromSlot(slot: number): number {
-    return Math.floor(slot / this.SLOTS_PER_EPOCH);
+    if (network == "gnosis"){
+      return Math.floor(slot / this.SLOTS_PER_EPOCH_GNOSIS);
+    } else {
+      return Math.floor(slot / this.SLOTS_PER_EPOCH);
+    }
   }
 }


### PR DESCRIPTION
I'm not certain, but this might fix issue #255 

I had an issue exiting a gnosis home staking validator, I found others with the same issue on [reddit](https://www.reddit.com/r/ethfinance/comments/16gi7gg/comment/k0azvw5/?utm_source=share&utm_medium=web2x&context=3) with teku.

I think this is due to incorrect epoch calculation using 32 slots per epoch instead of [16 on gnosis chain](https://github.com/gnosischain/prysm-launch/blob/4163b9fddd57bcc07293d9a6d0723baec1fb0675/config/config.yml#L76)

This PR adds network aware epoch calculation.

FYI I did zero testing, but I think this should solve it.

lmk what you think.