### PR TITLE
Set 16 slots per epoch in gnosis beaconchain API

### DIFF
--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -52,7 +52,10 @@ export const validatorApi = new ValidatorApi({
   authToken: token,
   tlsCert,
 });
-export const beaconchainApi = new Beaconchain({ baseUrl: beaconchainUrl });
+export const beaconchainApi = new Beaconchain(
+  { baseUrl: beaconchainUrl },
+  network
+);
 
 // Create DB instance
 export const brainDb = new BrainDataBase(

--- a/packages/brain/src/modules/apiClients/beaconchain/index.ts
+++ b/packages/brain/src/modules/apiClients/beaconchain/index.ts
@@ -113,7 +113,6 @@ export class Beaconchain extends StandardApi {
    */
   public async getCurrentEpoch(): Promise<number> {
     const head = await this.getBlockHeader({ block_id: "head" });
-    console.log("head", head.data);
     return this.getEpochFromSlot(parseInt(head.data.header.message.slot));
   }
 
@@ -146,7 +145,6 @@ export class Beaconchain extends StandardApi {
    * @param slot - The slot number.
    */
   private getEpochFromSlot(slot: number): number {
-    console.log("slot", slot);
     return Math.floor(slot / this.SLOTS_PER_EPOCH);
   }
 }

--- a/packages/brain/src/modules/apiClients/beaconchain/index.ts
+++ b/packages/brain/src/modules/apiClients/beaconchain/index.ts
@@ -4,13 +4,20 @@ import {
   BeaconchainPoolVoluntaryExitsPostRequest,
   BeaconchainForkFromStateGetResponse,
   BeaconchainGenesisGetResponse,
+  Network,
+  ApiParams,
 } from "@stakingbrain/common";
 import { StandardApi } from "../index.js";
 import path from "path";
 
 export class Beaconchain extends StandardApi {
-  private SLOTS_PER_EPOCH = 32;
+  private SLOTS_PER_EPOCH: number;
   private beaconchainEndpoint = "/eth/v1/beacon";
+
+  constructor(apiParams: ApiParams, network: Network) {
+    super(apiParams);
+    this.SLOTS_PER_EPOCH = network === "gnosis" ? 16 : 32;
+  }
 
   /**
    * Submits SignedVoluntaryExit object to node's pool and if passes validation node MUST broadcast it to network.
@@ -106,6 +113,7 @@ export class Beaconchain extends StandardApi {
    */
   public async getCurrentEpoch(): Promise<number> {
     const head = await this.getBlockHeader({ block_id: "head" });
+    console.log("head", head.data);
     return this.getEpochFromSlot(parseInt(head.data.header.message.slot));
   }
 
@@ -138,6 +146,7 @@ export class Beaconchain extends StandardApi {
    * @param slot - The slot number.
    */
   private getEpochFromSlot(slot: number): number {
+    console.log("slot", slot);
     return Math.floor(slot / this.SLOTS_PER_EPOCH);
   }
 }


### PR DESCRIPTION
The gnosis chain uses 16 slots per epoch instead of 32 (Ethereum). This was causing issues for exits signatures

See contract deployment https://docs.gnosischain.com/specs/gbc/