### PR TITLE
Add signer api healthcheck on realoadValidators

### DIFF
--- a/packages/brain/src/modules/cron/index.ts
+++ b/packages/brain/src/modules/cron/index.ts
@@ -70,7 +70,7 @@ export class Cron {
       // This is done to avoid unintended DB modifications when the API is down.
       // Status can be "UP" | "DOWN" | "UNKNOWN" | "LOADING" | "ERROR";
       if (signerApiStatus.status !== "UP") {
-        logger.debug(`Web3Signer is not UP. Skipping data reload until UP. Trying again in ${this.defaultInterval / 1000} seconds`);
+        logger.warn(`Web3Signer is ${signerApiStatus.status}. Skipping data reload until Web3Signer is UP. Trying again in ${this.defaultInterval / 1000} seconds`);
         return;
       }
 


### PR DESCRIPTION
Added a healthcheck on reloadValidators() at the very beginning of it. This is done to avoid unintended DB modifications when the web3signer is down and cant load correctly all validators. We must assure that all data is correct and loaded correctly when trying to persist the truth in our DB.

Also improved a bit error handling by logging an error if `if (e instanceof ApiError && e.code) {` doesnt check.

This should be tested thoroughly