### PR TITLE
Add error handling on response when doing requests

### DIFF
--- a/packages/brain/src/modules/apiClients/index.ts
+++ b/packages/brain/src/modules/apiClients/index.ts
@@ -155,6 +155,21 @@ export class StandardApi {
               );
             }
           });
+          res.on("error", (e: ErrnoException) => {
+            reject(
+              new ApiError({
+                name: e.name || "Standard ApiError",
+                message: `${e.message}. ` || "",
+                errno: e.errno || -1,
+                code: e.code || "UNKNOWN",
+                path: endpoint,
+                syscall: method,
+                hostname: this.requestOptions.hostname || undefined,
+                address: e.address,
+                port: e.port,
+              })
+            );
+          });
         });
       }
     );


### PR DESCRIPTION
StakingBrain `request()` method had no handling for a response with an error. This made the code to be stuck when an error was returned, since there was no `reject()` or `resolve()` for that case. 

This bug was found by brain UI being stuck when trying to delete a validator while using Lodestar holesky as a consensus client, since it's validator API seems to be failing when trying to delete a fee_recipient for a given pubkey