### PR TITLE
Validator API response status to lower case

### DIFF
--- a/packages/brain/src/calls/importValidators.ts
+++ b/packages/brain/src/calls/importValidators.ts
@@ -120,16 +120,18 @@ export async function importValidators(
 
     //Iterate over pubkeysToPost with index and pubkey
     for (const [index, pubkey] of pubkeysToPostIterator) {
-      if (web3signerPostResponse.data[index].status === "error") {
+      const postStatus = web3signerPostResponse.data[index].status;
+
+      if (postStatus === "error") {
         web3signerPostResponse.data[index].message +=
           ". Check that the keystore file format is valid and the password is correct.";
         logger.error(
           `Error importing keystore for pubkey ${shortenPubkey(pubkey)}: ${web3signerPostResponse.data[index].message
           }`
         );
-      } else if (web3signerPostResponse.data[index].status === "duplicate") {
+      } else if (postStatus === "duplicate") {
         logger.warn(`Duplicate keystore for pubkey ${shortenPubkey(pubkey)}`);
-      } else if (web3signerPostResponse.data[index].status === "imported") {
+      } else if (postStatus === "imported") {
         validatorsToPost.push(validators[index]);
       }
     }

--- a/packages/brain/src/modules/apiClients/validator/index.ts
+++ b/packages/brain/src/modules/apiClients/validator/index.ts
@@ -116,11 +116,13 @@ export class ValidatorApi extends StandardApi {
       remoteKeys.remote_keys = remoteKeys.remote_keys.map((k) => {
         return { pubkey: prefix0xPubkey(k.pubkey), url: k.url };
       });
-      return (await this.request({
+      const response = (await this.request({
         method: "POST",
         endpoint: this.remoteKeymanagerEndpoint,
         body: JSON.stringify(remoteKeys)
       })) as ValidatorPostRemoteKeysResponse;
+
+      return this.toLowerCaseStatus(response);
     } catch (e) {
       e.message += `Error posting (POST) remote keys to validator. `;
       throw e;
@@ -137,14 +139,29 @@ export class ValidatorApi extends StandardApi {
     try {
       // Make sure all pubkeys are prefixed with 0x
       pubkeys.pubkeys = pubkeys.pubkeys.map((k) => prefix0xPubkey(k));
-      return (await this.request({
+      const response = (await this.request({
         method: "DELETE",
         endpoint: this.remoteKeymanagerEndpoint,
         body: JSON.stringify(pubkeys)
       })) as ValidatorDeleteRemoteKeysResponse;
+
+      return this.toLowerCaseStatus(response);
     } catch (e) {
       e.message += `Error deleting (DELETE) remote keys from validator. `;
       throw e;
     }
+  }
+
+  /**
+ * Converts the status to lowercase for Web3SignerPostResponse and Web3SignerDeleteResponse
+ */
+  private toLowerCaseStatus<T extends ValidatorPostRemoteKeysResponse | ValidatorDeleteRemoteKeysResponse>(validatorResponse: T): T {
+    return {
+      ...validatorResponse,
+      data: validatorResponse.data.map((item) => ({
+        ...item,
+        status: item.status.toLowerCase()
+      })),
+    } as T;
   }
 }


### PR DESCRIPTION
Prysm v5.0.0 validator API returns status in upper case (e.g. IMPORTED) so this needs to be handled at the moment of handling the response in the brain