### PR TITLE
Add proxy to keystores get

### DIFF
--- a/packages/brain/src/modules/apiServers/launchpad/routes/keystores/route.ts
+++ b/packages/brain/src/modules/apiServers/launchpad/routes/keystores/route.ts
@@ -5,6 +5,7 @@ import { importValidators } from "../../../../../calls/index.js";
 import { BrainKeystoreImportRequest } from "../../types.js";
 import { validateDeleteRequestBody, validateImportKeystoresRequestBody } from "./validation.js";
 import logger from "../../../../logger/index.js";
+import { signerApi } from "../../../../../index.js";
 
 const keystoresRouter = express.Router();
 
@@ -57,6 +58,17 @@ keystoresRouter.delete(keystoresEndpoint, async (req, res) => {
         const deleteResponse = await deleteValidators(deleteRequest);
 
         res.status(200).send(deleteResponse);
+    } catch (e) {
+        logger.error(e);
+        res.status(500).send({ message: "Internal server error" });
+    }
+});
+
+keystoresRouter.get(keystoresEndpoint, async (_req, res) => {
+    try {
+        const getResponse = await signerApi.getKeystores();
+
+        res.status(200).send(getResponse);
     } catch (e) {
         logger.error(e);
         res.status(500).send({ message: "Internal server error" });


### PR DESCRIPTION
Now the brain can handle GET requests to  `/eth/v1/keystores`. It essentially proxies the request to the web3signer. This will be used by the Stakewise package