### PR TITLE
Fix #263 Update index.ts allowing rocketpool validators to set a custom fee recipient address

### DIFF
--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -23,7 +23,7 @@ export function isValidTag(tag: Tag): boolean {
 
 export function isFeeRecipientEditable(tag: Tag, requestOrigin?: ActionRequestOrigin): boolean {
 
-  if (requestOrigin === "api" && tag === "stader") return true;
+  if (requestOrigin === "api" && (tag === "stader" || tag === "rocketpool")) return true;
 
   return !nonEditableFeeRecipientTags.some((t) => t === tag);
 }


### PR DESCRIPTION
Fixed #263 @pablomendezroyo @dappnodedev Give some ❤️ to this change 🙏 Generate the web3signer-holesky package with this change is mandatory for publishing rocketpool-testnet. RP changed the fee recipient address when they changed the network from prater to holesky. Right now the smoothing pool address isn't equal to mainnet