### PR TITLE
Add MEV warning on keystore lido imports

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.9"
 services:
   brain:
     build:

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -123,8 +123,10 @@ function App(): JSX.Element {
               />
               <Route
                 path="import"
-                element={<ImportScreen network={stakerConfig.network} />}
-              />            
+                element={
+                  <ImportScreen 
+                  network={stakerConfig.network}
+                  isMevBoostSet={stakerConfig.isMevBoostSet} />}              />            
               </Routes>
           </BrowserRouter>
         )

--- a/packages/ui/src/ImportScreen.tsx
+++ b/packages/ui/src/ImportScreen.tsx
@@ -473,7 +473,7 @@ export default function ImportScreen({
             <Link to={network === 'holesky' ? 'http://my.dappnode/stakers/holesky' : 'http://my.dappnode/stakers/ethereum'}>
               your stakers tab
             </Link> before importing your Lido validator. Visit{' '}
-            <Link to="http://docs.dappnode.io">
+            <Link to="https://docs.dappnode.io/docs/user/staking/ethereum/lsd-pools/lido">
               our docs
             </Link> for more details.
           </Alert>

--- a/packages/ui/src/ImportScreen.tsx
+++ b/packages/ui/src/ImportScreen.tsx
@@ -57,13 +57,13 @@ export default function ImportScreen({
   const [useSameFeerecipient, setUseSameFeerecipient] = useState(false);
   const [importStatus, setImportStatus] = useState(ImportStatus.NotImported);
   const [showMevWarning, setShowMevWarning] = useState(false);
-
+  
   // This use effect sets the Lido warning when one of the keystores has the 'lido' tag and MEV-Boost is not set
   useEffect(() => {
-    // Check if any of the selected tags is 'lido' and MEV-Boost is not set
-    const lidoSelected = tags.includes('lido');
+      // Check if any of the selected tags is 'lido' and MEV-Boost is not set
+      const lidoSelected = tags.includes('lido');
 
-    setShowMevWarning(lidoSelected && !isMevBoostSet);
+      setShowMevWarning(lidoSelected && !isMevBoostSet);
   }, [tags, isMevBoostSet]);
 
 
@@ -280,9 +280,6 @@ export default function ImportScreen({
                           setTags(
                             Array(acceptedFiles.length).fill(e.target.value)
                           );
-
-                          setShowMevWarning(e.target.value === 'lido' && !isMevBoostSet);
-
                           if (!isFeeRecipientEditable(tags[0])) {
                             setFeeRecipients(
                               Array(acceptedFiles.length).fill("")
@@ -298,14 +295,6 @@ export default function ImportScreen({
                       </Select>
                       <FormHelperText>Staking protocol</FormHelperText>
                     </>
-                  )}
-                  {showMevWarning && (
-                    <Alert severity="warning">
-                      To have a Lido validator, you must have the MEV-Boost package installed. Visit
-                      <Link to={network === 'holesky' ? 'http://my.dappnode/stakers/holesky' : 'http://my.dappnode/stakers/ethereum'}>
-                        this link
-                      </Link> for more details.
-                    </Alert>
                   )}
                   {useSameFeerecipient && (
                     <>
@@ -418,7 +407,22 @@ export default function ImportScreen({
             </div>
           ) : null}
         </Card>
-
+        {showMevWarning && (
+          <Alert severity="warning" sx={{
+            marginTop: 4,
+            display: "flex",
+          }}>
+            You are importing one or more "Lido" validators, but don't have the MEV Boost package up & running.
+            As a Lido Node Operator, it is your responsibility to ensure that your validators use MEV boost. <br/> Please install the MEV Boost package from{' '}
+            <Link to={network === 'holesky' ? 'http://my.dappnode/stakers/holesky' : 'http://my.dappnode/stakers/ethereum'}>
+              your stakers tab
+            </Link> before importing your Lido validator. Visit{' '}
+            <Link to="http://docs.dappnode.io">
+              our docs
+            </Link> for more details.
+          </Alert>
+        
+          )}
         <Box
           sx={{
             marginTop: 4,
@@ -439,14 +443,6 @@ export default function ImportScreen({
               Back to Accounts
             </Button>
           </Link>
-          {showMevWarning && (
-            <Alert severity="warning">
-              To have a Lido validator, you must have the MEV-Boost package installed. Visit
-              <Link to={network === 'holesky' ? 'http://my.dappnode/stakers/holesky' : 'http://my.dappnode/stakers/ethereum'}>
-                this link
-              </Link> for more details.
-            </Alert>
-          )}
 
           <Button
             variant="contained"

--- a/packages/ui/src/ImportScreen.tsx
+++ b/packages/ui/src/ImportScreen.tsx
@@ -56,7 +56,35 @@ export default function ImportScreen({
   const [feeRecipients, setFeeRecipients] = useState<string[]>([]);
   const [useSameFeerecipient, setUseSameFeerecipient] = useState(false);
   const [importStatus, setImportStatus] = useState(ImportStatus.NotImported);
+  const [slashingFile, setSlashingFile] = useState<File>();
   const [showMevWarning, setShowMevWarning] = useState(false);
+  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+
+  // If the user has selected the 'lido' tag and MEV-Boost is not set, show the warning
+  useEffect(() => {
+    const lidoSelected = tags.includes('lido');
+    setShowMevWarning(lidoSelected && !isMevBoostSet);
+  }, [tags, isMevBoostSet]);
+
+
+  // Function to handle "use same password/fee recipient/tag" switches toggling
+  const handleSwitchToggle = (switchType: 'password' | 'tag' | 'feerecipient') => {
+    switch (switchType) {
+      case 'password':
+        setUseSamePassword(!useSamePassword);  // Directly toggle the boolean state
+        setPasswords([]);  // Reset passwords to empty
+        break;
+      case 'tag':
+        setUseSameTag(!useSameTag);  // Directly toggle the boolean state
+        setTags([]);  // Reset tags to empty
+        break;
+      case 'feerecipient':
+        setUseSameFeerecipient(!useSameFeerecipient);  // Directly toggle the boolean state
+        setFeeRecipients([]);  // Reset fee recipients to empty
+        break;
+    }
+  };
+  
   
   // This use effect sets the Lido warning when one of the keystores has the 'lido' tag and MEV-Boost is not set
   useEffect(() => {
@@ -66,7 +94,7 @@ export default function ImportScreen({
       setShowMevWarning(lidoSelected && !isMevBoostSet);
   }, [tags, isMevBoostSet]);
 
-
+  
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const keystoreFilesCallback = async (files: File[], event: DropEvent) => {
     const keystoresToAdd: KeystoreInfo[] = [];
@@ -84,7 +112,6 @@ export default function ImportScreen({
     setPasswords([...passwords].concat(passwordsToAdd));
   };
 
-  const [slashingFile, setSlashingFile] = useState<File>();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const slashingFilesCallback = (files: File[], event: DropEvent) => {
     setSlashingFile(files[0]);
@@ -103,6 +130,37 @@ export default function ImportScreen({
   const handleClickOpenDialog = () => {
     setOpenDialog(true);
   };
+
+  // This useEffect updates the "submit keystores" button state based on various conditions,
+  // such as if any password is empty, if any tag is empty, if any fee recipient is invalid, etc.
+  useEffect(() => {
+    const isAnyPasswordEmpty = () => {
+      return passwords.some(password => password === "") || passwords.length === 0;
+    };
+
+    const hasInvalidTagOrFeeRecipient = () => {
+      if (tags.length !== acceptedFiles.length) return true;
+      return tags.some((tag, index) => {
+        if (tag.length === 0) return true;
+        if (isFeeRecipientEditable(tag)) {
+          return !isValidEcdsaPubkey(feeRecipients[index]);
+        }
+        return false;
+      });
+    };
+
+    const hasInvalidKeystoreData = () => {
+      return isAnyPasswordEmpty() || hasInvalidTagOrFeeRecipient();
+    };
+
+    const disable = acceptedFiles.length === 0 ||
+                    (!slashingFile && slashingProtectionIncluded) ||
+                    hasInvalidKeystoreData() ||
+                    showMevWarning;
+
+    setIsButtonDisabled(disable);  // Set the state based on the conditions
+  }, [passwords, tags, feeRecipients, acceptedFiles, slashingFile, slashingProtectionIncluded, showMevWarning]);
+
 
   async function importKeystores() {
     try {
@@ -228,7 +286,7 @@ export default function ImportScreen({
                 <FormControlLabel
                   control={
                     <Switch
-                      onChange={() => setUseSamePassword(!useSamePassword)}
+                      onChange={() => handleSwitchToggle('password')}
                     />
                   }
                   label="Use same password for every file"
@@ -236,16 +294,14 @@ export default function ImportScreen({
                 <FormControlLabel
                   control={
                     <Switch
-                      onChange={() =>
-                        setUseSameFeerecipient(!useSameFeerecipient)
-                      }
+                      onChange={() => handleSwitchToggle('feerecipient')}
                     />
                   }
                   label="Use same fee recipient for every file"
                 />
                 <FormControlLabel
                   control={
-                    <Switch onChange={() => setUseSameTag(!useSameTag)} />
+                    <Switch onChange={() => handleSwitchToggle('tag')} />
                   }
                   label="Use same tag for every file"
                 />
@@ -448,20 +504,7 @@ export default function ImportScreen({
             variant="contained"
             size="large"
             endIcon={<BackupIcon />}
-            disabled={
-              acceptedFiles.length === 0 ||
-              (!slashingFile && slashingProtectionIncluded) ||
-              passwords.some((password) => password.length === 0) ||
-              tags.some((tag, index) => {
-                if (tag.length === 0) return true;
-                // If tag is editable, check if fee recipient is valid
-                if (isFeeRecipientEditable(tag)) {
-                  return !isValidEcdsaPubkey(feeRecipients[index]);
-                }
-                return false;
-              }) ||
-              showMevWarning  // Disable button if Mev warning is shown
-            }
+            disabled={isButtonDisabled}
             onClick={importKeystores}
             sx={{ borderRadius: 3 }}
           >


### PR DESCRIPTION
- Added MEV warning when user has a validator imported with "Lido" tag but Mev-Boost is not installed:
![Screenshot_20240628_171218](https://github.com/dappnode/StakingBrain/assets/36164126/bc86baee-fdda-4f99-8a64-886ae27081e7)

- Updated "submit keystore" disabled button to be disabled when any tags, passwords or editable fee recipients are empty, aswell as when "Lido" tag and no mevboost is detected
- Fixed minor bugs regarding "Use same password/FR/Tag": switch was not applying same values if user previously selected different tags/fee recipient