### PR TITLE
Add missing endpoints to validator and beaconchain API clients required to calculate validator performance

### DIFF
--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -32,6 +32,7 @@
     "@types/lowdb": "^1.0.11",
     "@types/sinon": "^10.0.13",
     "rimraf": "^4.1.1",
-    "sinon": "^15.0.1"
+    "sinon": "^15.0.1",
+    "typescript": "^5.5.4"
   }
 }

--- a/packages/brain/src/calls/exitValidators.ts
+++ b/packages/brain/src/calls/exitValidators.ts
@@ -67,7 +67,7 @@ async function _getExitValidators(pubkeys: string[]): Promise<ValidatorExitGet[]
   const currentEpoch = await beaconchainApi.getCurrentEpoch();
 
   // Get the fork from the beaconchain API to sign the voluntary exit
-  const fork = await beaconchainApi.getForkFromState({ state_id: "head" });
+  const fork = await beaconchainApi.getForkFromState({ stateId: "head" });
 
   // Get the genesis from the beaconchain API to sign the voluntary exit
   const genesis = await beaconchainApi.getGenesis();

--- a/packages/brain/src/modules/apiClients/beaconcha.ts
+++ b/packages/brain/src/modules/apiClients/beaconcha.ts
@@ -4,7 +4,7 @@ import { BeaconchaGetResponse } from "@stakingbrain/common";
 const maxValidatorsPerRequest = 100; //For beaconcha.in --> TODO: is it the same for Gnosis?
 
 export class BeaconchaApi extends StandardApi {
-  /*
+  /**
    * Fetch info for every validator PK
    */
   public async fetchAllValidatorsInfo({ pubkeys }: { pubkeys: string[] }): Promise<BeaconchaGetResponse[]> {

--- a/packages/brain/src/modules/apiClients/beaconchain.ts
+++ b/packages/brain/src/modules/apiClients/beaconchain.ts
@@ -4,6 +4,7 @@ import {
   BeaconchainPoolVoluntaryExitsPostRequest,
   BeaconchainForkFromStateGetResponse,
   BeaconchainGenesisGetResponse,
+  BeaconchainStateFinalityCheckpointsPostResponse,
   Network,
   ApiParams
 } from "@stakingbrain/common";
@@ -60,16 +61,41 @@ export class Beaconchain extends StandardApi {
   /**
    * Get Fork object from requested state.
    * @see https://ethereum.github.io/beacon-APIs/#/Beacon/getStateFork
-   * @param state_id - State identifier. Can be one of: "head" (canonical head in node's view), "genesis", "finalized", <slot>, <hex encoded stateRoot with 0x prefix>.
+   * @param stateId - State identifier. Can be one of: "head" (canonical head in node's view), "genesis", "finalized", <slot>, <hex encoded stateRoot with 0x prefix>.
    */
-  public async getForkFromState({ state_id }: { state_id: string }): Promise<BeaconchainForkFromStateGetResponse> {
+  public async getForkFromState({
+    stateId
+  }: {
+    stateId: "head" | "genesis" | "finalized";
+  }): Promise<BeaconchainForkFromStateGetResponse> {
     try {
       return (await this.request({
         method: "GET",
-        endpoint: path.join(this.beaconchainEndpoint, "states", state_id, "fork")
+        endpoint: path.join(this.beaconchainEndpoint, "states", stateId, "fork")
       })) as BeaconchainForkFromStateGetResponse;
     } catch (e) {
       e.message += `Error getting (GET) fork from beaconchain. `;
+      throw e;
+    }
+  }
+
+  /**
+   * Returns finality checkpoints for state with given 'stateId'. In case finality is not yet achieved, checkpoint should return epoch 0 and ZERO_HASH as root.
+   * @see https://ethereum.github.io/beacon-APIs/#/Beacon/getStateFinalityCheckpoints
+   * @param stateId - State identifier. Can be one of: "head" (canonical head in node's view), "genesis", "finalized", <slot>, <hex encoded stateRoot with 0x prefix>.
+   */
+  public async getStateFinalityCheckpoints({
+    stateId
+  }: {
+    stateId: "head" | "genesis" | "finalized";
+  }): Promise<BeaconchainStateFinalityCheckpointsPostResponse> {
+    try {
+      return await this.request({
+        method: "GET",
+        endpoint: path.join(this.beaconchainEndpoint, "states", stateId, "finality_checkpoints")
+      });
+    } catch (e) {
+      e.message += `Error getting (GET) state finality checkpoints from beaconchain. `;
       throw e;
     }
   }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@types/sinon": "^10.0.13",
-    "sinon": "^15.0.1"
+    "sinon": "^15.0.1",
+    "typescript": "^5.5.4"
   }
 }

--- a/packages/common/src/types/api/beaconchain/types.ts
+++ b/packages/common/src/types/api/beaconchain/types.ts
@@ -52,6 +52,25 @@ export interface BeaconchainForkFromStateGetResponse {
   };
 }
 
+export interface BeaconchainStateFinalityCheckpointsPostResponse {
+  execution_optimistic: boolean;
+  finalized: boolean;
+  data: {
+    previous_justified: {
+      epoch: string;
+      root: string;
+    };
+    current_justified: {
+      epoch: string;
+      root: "string";
+    };
+    finalized: {
+      epoch: string;
+      root: "string";
+    };
+  };
+}
+
 export interface BeaconchainGenesisGetResponse {
   data: {
     genesis_time: string;

--- a/packages/common/src/types/api/validator/types.ts
+++ b/packages/common/src/types/api/validator/types.ts
@@ -41,6 +41,30 @@ export interface ValidatorDeleteRemoteKeysResponse {
   }[];
 }
 
+export interface ValidatorAttesterDutiesPostResponse {
+  dependent_root: string;
+  execution_optimistic: boolean;
+  data: {
+    pubkey: string;
+    validator_index: string;
+    committee_index: string;
+    committee_length: string;
+    committees_at_slot: string;
+    validator_committee_index: string;
+    slot: string;
+  }[];
+}
+
+export interface ValidatorProposerDutiesGetResponse {
+  dependent_root: string;
+  execution_optimistic: false;
+  data: {
+    pubkey: string;
+    validator_index: string;
+    slot: string;
+  }[];
+}
+
 export interface ValidatorExitGet extends BeaconchainPoolVoluntaryExitsPostRequest {
   pubkey: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3055,6 +3055,7 @@ __metadata:
     rimraf: "npm:^4.1.1"
     sinon: "npm:^15.0.1"
     socket.io: "npm:^4.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -3064,6 +3065,7 @@ __metadata:
   dependencies:
     "@types/sinon": "npm:^10.0.13"
     sinon: "npm:^15.0.1"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Add missing endpoints to validator and beaconchain API clients.

- Beaconchain
  - `getStateFinalityCheckpoints`
- Validator:
  - `getAttesterDuties`
  - `getProposerDuties`