### PR TITLE
add block proposal duties into db

### DIFF
--- a/packages/brain/src/modules/apiClients/beaconchain/index.ts
+++ b/packages/brain/src/modules/apiClients/beaconchain/index.ts
@@ -12,14 +12,16 @@ import {
   BeaconchainLivenessPostResponse,
   BeaconchainSyncingStatusGetResponse,
   BeaconchainSyncCommitteePostResponse,
-  BeaconchainBlockRewardsGetResponse
+  BeaconchainBlockRewardsGetResponse,
+  BeaconchainProposerDutiesGetResponse
 } from "./types.js";
 import { StandardApi } from "../standard.js";
 import path from "path";
 import { ApiParams } from "../types.js";
 import { Network } from "@stakingbrain/common";
 
-type BlockId = "head" | "genesis" | "finalized" | "slot" | `0x${string}`;
+// TODO: BlockId can also be a simple slot in the form of a string. Is this type still necessary?
+type BlockId = "head" | "genesis" | "finalized" | string | `0x${string}`;
 
 export class BeaconchainApi extends StandardApi {
   private SLOTS_PER_EPOCH: number;
@@ -269,6 +271,29 @@ export class BeaconchainApi extends StandardApi {
   }
 
   /**
+   * Retrieve block proposal duties for the specified epoch. This will return a list of 32 elements, each element corresponding to a slot in the epoch. 
+   * If the epoch requested is not yet finalized, a chain reorg is possible and the duties may change.
+   *
+   * @param epoch The epoch to get the proposer duties from
+   * @see https://ethereum.github.io/beacon-APIs/#/Validator/getProposerDuties
+   */
+  public async getProposerDuties({
+    epoch,
+  }: {
+    epoch: string;
+  }): Promise<BeaconchainProposerDutiesGetResponse> {
+    try {
+      return await this.request({
+        method: "GET",
+        endpoint: path.join(this.validatorEndpoint, "duties", "proposer", epoch),
+      });
+    } catch (e) {
+      e.message += `Error getting (GET) proposer duties from beaconchain. `;
+      throw e;
+    }
+  }
+
+  /**
    * Retrieve block reward info for a single block
    *
    * @param blockId Block identifier. Can be one of: "head" (canonical head in node's view), "genesis", "finalized", <slot>, <hex encoded blockRoot with 0x prefix>
@@ -340,7 +365,7 @@ export class BeaconchainApi extends StandardApi {
    * @params blockId Block identifier. Can be one of: "head" (canonical head in node's view), "genesis", "finalized", <slot>, <hex encoded blockRoot with 0x prefix>.
    * @example head
    */
-  private async getBlockHeader({ blockId }: { blockId: BlockId }): Promise<BeaconchainBlockHeaderGetResponse> {
+  public async getBlockHeader({ blockId }: { blockId: BlockId }): Promise<BeaconchainBlockHeaderGetResponse> {
     try {
       return await this.request({
         method: "GET",

--- a/packages/brain/src/modules/apiClients/beaconchain/types.ts
+++ b/packages/brain/src/modules/apiClients/beaconchain/types.ts
@@ -62,6 +62,16 @@ export interface BeaconchainAttestationRewardsPostResponse {
   };
 }
 
+export interface BeaconchainProposerDutiesGetResponse {
+  dependent_root: string; // The block root that the response is dependent on.
+  execution_optimistic: boolean; // Indicates whether the response references an unverified execution payload.
+  data: {
+    pubkey: string; // The validator's BLS public key, 48-bytes, hex encoded with 0x prefix.
+    validator_index: string; // The index of the validator in the validator registry.
+    slot: string; // The slot at which the validator must propose a block.
+  }[];
+}
+
 export interface BeaconchainSyncCommitteePostResponse {
   execution_optimistic: boolean;
   finalized: boolean;

--- a/packages/brain/src/modules/apiClients/postgres/types.ts
+++ b/packages/brain/src/modules/apiClients/postgres/types.ts
@@ -1,7 +1,8 @@
 export enum BlockProposalStatus {
   Missed = "Missed",
   Proposed = "Proposed",
-  Unchosen = "Unchosen"
+  Unchosen = "Unchosen",
+  Error = "Error"
 }
 
 export interface ValidatorPerformance {

--- a/packages/brain/src/modules/cron/trackValidatorsPerformance.ts
+++ b/packages/brain/src/modules/cron/trackValidatorsPerformance.ts
@@ -94,6 +94,45 @@ export async function trackValidatorsPerformance({
       ).data.total_rewards;
       logger.debug(`${logPrefix}Attestations rewards: ${JSON.stringify(validatorsAttestationsRewards)}`);
 
+      // Get block proposal duties
+      logger.debug(`${logPrefix}Getting block proposal duties for epoch ${epochFinalized}`);
+      const blockProposalsResponse = (
+        await beaconchainApi.getProposerDuties({
+          epoch: epochFinalized.toString(),
+        })
+      )
+
+      // Map to store the block proposal status of each validator
+      const validatorBlockStatus = new Map<string, BlockProposalStatus>();
+
+      // Initialize all validator's status to Unchosen.
+      validatorIndexes.forEach(validatorIndex => {
+        validatorBlockStatus.set(validatorIndex, BlockProposalStatus.Unchosen);
+      });
+
+      // Since we know block proposal duties, we can check if the validator proposed the block or missed it.
+      for (const duty of blockProposalsResponse.data) {
+        const { validator_index, slot } = duty;
+
+        if (validatorIndexes.includes(validator_index)) {
+          try {
+            const blockHeader = await beaconchainApi.getBlockHeader({ blockId: slot });
+            // Update status based on whether the validator in the block header matches the one supposed to propose
+            // If the duty had a proposer index and it doesn't match with the header proposer index, we did something wrong, so we consider it as an error
+            validatorBlockStatus.set(validator_index, blockHeader.data.header.message.proposer_index == validator_index ? BlockProposalStatus.Proposed : BlockProposalStatus.Error);
+          } catch (error) {
+            if (error.status === 404) {
+              // Consensus clients return 404 a block was missed (there is no block for the slot)
+              validatorBlockStatus.set(validator_index, BlockProposalStatus.Missed);
+            } else {
+              // If consensus client doesnt return 200 or 404, something went wrong
+              logger.error(`${logPrefix}Error retrieving block header for slot ${slot}: ${error}`);
+              validatorBlockStatus.set(validator_index, BlockProposalStatus.Error); // Something went wrong
+            }
+          }
+        }
+      }
+
       // insert performance data
       for (const validatorIndex of validatorIndexes) {
         //const liveness = validatorsLiveness.find((liveness) => liveness.index === validatorIndex)?.is_live;
@@ -106,12 +145,19 @@ export async function trackValidatorsPerformance({
           continue;
         }
 
+        const blockProposalStatus = validatorBlockStatus.get(validatorIndex);
+        if (!blockProposalStatus) {
+          logger.error(`${logPrefix}Missing block proposal data for validator ${validatorIndex}, block: ${blockProposalStatus}`);
+          continue;
+        }
+        logger.debug(` blockProposalStatus: ${blockProposalStatus}`);
+
         // write on db
         logger.debug(`${logPrefix}Inserting performance data for validator ${validatorIndex}`);
         await postgresClient.insertPerformanceData({
           validatorIndex: parseInt(validatorIndex),
           epoch: epochFinalized,
-          blockProposalStatus: BlockProposalStatus.Missed, // TODO: how to get the block proposal status?
+          blockProposalStatus: blockProposalStatus,
           attestationsRewards
         });
       }

--- a/packages/brain/src/modules/cron/trackValidatorsPerformance.ts
+++ b/packages/brain/src/modules/cron/trackValidatorsPerformance.ts
@@ -150,7 +150,6 @@ export async function trackValidatorsPerformance({
           logger.error(`${logPrefix}Missing block proposal data for validator ${validatorIndex}, block: ${blockProposalStatus}`);
           continue;
         }
-        logger.debug(` blockProposalStatus: ${blockProposalStatus}`);
 
         // write on db
         logger.debug(`${logPrefix}Inserting performance data for validator ${validatorIndex}`);


### PR DESCRIPTION
Checking the block proposal status can be broken down into two steps:
- Check Proposer Duties: Did my validator X have the responsibility to propose a block during this epoch? If yes, for which slot?
- Check if the Duty was Fulfilled: Was a block proposed during the assigned slot? Was my validator the one that proposed it?