### PR TITLE
refactor cron

### DIFF
--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -98,51 +98,35 @@ const proofOfValidationCron = new CronJob(shareCronInterval, () =>
 );
 proofOfValidationCron.start();
 
-// defned outside of cron to keep track of the latest processed epoch
-// this must persist even if brain is stoped! 
-// we should read db and get the latest processed epoch from there
-let latestProcessedEpoch: number | undefined;
-
-// executes once each minute, TBD 
-const trackValidatorsPerformanceCron = new CronJob(60 * 1000, async () => {
-
+// executes once every epoch
+const trackValidatorsPerformanceCron = new CronJob(slotsPerEpoch * secondsPerSlot * 1000, async () => {
   try {
-    const currentEpoch = await beaconchainApi.getEpochHeader({ blockId: 'finalized' });
-
-    if (!latestProcessedEpoch || currentEpoch > latestProcessedEpoch) {
-      await trackValidatorsPerformance({
-        brainDb,
-        postgresClient,
-        currentEpoch,
-        beaconchainApi,
-        minGenesisTime,
-        secondsPerSlot,
-        executionClient,
-        consensusClient
-      });
-      // update latestProcessedEpoch
-      latestProcessedEpoch = currentEpoch;
-    } else {
-      console.log('No new epoch to process.');
-    }
-  }
-  catch (err) {
-    logger.error(`Error in trackValidatorsPerformanceCron`, err);
+    const currentEpoch = await beaconchainApi.getEpochHeader({ blockId: "finalized" });
+    await trackValidatorsPerformance({
+      currentEpoch,
+      brainDb,
+      postgresClient,
+      beaconchainApi,
+      executionClient,
+      consensusClient
+    });
+  } catch (e) {
+    logger.error(`Error tracking validator performance: ${e}`);
   }
 });
-
-
+// if we are in the first 10% of the epoch we start the cron job if not we wait until the next epoch with a timeout.
+// gnosis chain 80 seconds per epoch -> 8 seconds
+// ethereum 384 seconds per epoch -> 38.4 seconds
 const secondsToNextEpoch = getSecondsToNextEpoch({ minGenesisTime, secondsPerSlot });
-// start the cron within the first minute of an epoch
-// If it remains more than 1 minute then wait for the next epoch (+ 10 seconds of margin)
-if (secondsToNextEpoch > 60) setTimeout(() => trackValidatorsPerformanceCron.start(), (secondsToNextEpoch + 10) * 1000);
-else trackValidatorsPerformanceCron.start();
+if (secondsToNextEpoch <= slotsPerEpoch * secondsPerSlot * 0.1) trackValidatorsPerformanceCron.start();
+else setTimeout(() => trackValidatorsPerformanceCron.start(), (secondsToNextEpoch + 3) * 1000);
 
 // Graceful shutdown
 function handle(signal: string): void {
   logger.info(`${signal} received. Shutting down...`);
   reloadValidatorsCron.stop();
   proofOfValidationCron.stop();
+  trackValidatorsPerformanceCron.stop();
   brainDb.close();
   postgresClient.close().catch((err) => logger.error(`Error closing postgres client`, err)); // postgresClient db connection is the only external resource that needs to be closed
   uiServer.close();

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -100,28 +100,34 @@ proofOfValidationCron.start();
 
 // defned outside of cron to keep track of the latest processed epoch
 // this must persist even if brain is stoped! 
+// we should read db and get the latest processed epoch from there
 let latestProcessedEpoch: number | undefined;
 
 // executes once each minute, TBD 
 const trackValidatorsPerformanceCron = new CronJob(60 * 1000, async () => {
 
-  const currentEpoch = await beaconchainApi.getEpochHeader({ blockId: 'finalized' });
+  try {
+    const currentEpoch = await beaconchainApi.getEpochHeader({ blockId: 'finalized' });
 
-  if (!latestProcessedEpoch || currentEpoch > latestProcessedEpoch) {
-    await trackValidatorsPerformance({
-      brainDb,
-      postgresClient,
-      currentEpoch,
-      beaconchainApi,
-      minGenesisTime,
-      secondsPerSlot,
-      executionClient,
-      consensusClient
-    });
-    // update latestProcessedEpoch
-    latestProcessedEpoch = currentEpoch;
-  } else {
-    console.log('No new epoch to process.');
+    if (!latestProcessedEpoch || currentEpoch > latestProcessedEpoch) {
+      await trackValidatorsPerformance({
+        brainDb,
+        postgresClient,
+        currentEpoch,
+        beaconchainApi,
+        minGenesisTime,
+        secondsPerSlot,
+        executionClient,
+        consensusClient
+      });
+      // update latestProcessedEpoch
+      latestProcessedEpoch = currentEpoch;
+    } else {
+      console.log('No new epoch to process.');
+    }
+  }
+  catch (err) {
+    logger.error(`Error in trackValidatorsPerformanceCron`, err);
   }
 });
 

--- a/packages/brain/src/modules/cron/trackValidatorsPerformance/insertPerformanceData.ts
+++ b/packages/brain/src/modules/cron/trackValidatorsPerformance/insertPerformanceData.ts
@@ -19,7 +19,7 @@ import { logPrefix } from "./logPrefix.js";
 export async function insertPerformanceDataNotThrow({
   postgresClient,
   activeValidatorsIndexes,
-  epochFinalized,
+  currentEpoch,
   validatorBlockStatusMap,
   validatorsAttestationsTotalRewards,
   executionClient,
@@ -28,7 +28,7 @@ export async function insertPerformanceDataNotThrow({
 }: {
   postgresClient: PostgresClient;
   activeValidatorsIndexes: string[];
-  epochFinalized: number;
+  currentEpoch: number;
   validatorBlockStatusMap: Map<string, BlockProposalStatus>;
   validatorsAttestationsTotalRewards: TotalRewards[];
   executionClient: ExecutionClient;
@@ -58,14 +58,14 @@ export async function insertPerformanceDataNotThrow({
       logger.debug(`${logPrefix}Inserting performance data for validator ${validatorIndex}`);
       await postgresClient.insertPerformanceData({
         validatorIndex: parseInt(validatorIndex),
-        epoch: epochFinalized,
+        epoch: currentEpoch,
         blockProposalStatus,
         attestationsTotalRewards,
         error: error?.message,
         executionClient,
         consensusClient
       });
-      logger.debug(`${logPrefix}Performance data inserted for epoch ${epochFinalized}`);
+      logger.debug(`${logPrefix}Performance data inserted for epoch ${currentEpoch}`);
     } catch (e) {
       logger.error(`${logPrefix}Error inserting performance data for validator ${validatorIndex}: ${e}`);
       continue;


### PR DESCRIPTION
cron is executed each minute. If the current epoch hasnt been processed, the cron calls `trackValidatorsPerformance()`, it doesnt matter if the epoch is about to end.

TODO: figure a way to store latest processed epoch that persists when brain container is stopped