### PR TITLE
Fix tls certificate for teku validator API

### DIFF
--- a/packages/brain/src/modules/config/networks/gnosis.ts
+++ b/packages/brain/src/modules/config/networks/gnosis.ts
@@ -28,6 +28,6 @@ export const gnosisBrainConfig = (
     postgresUrl: "postgres://postgres:gnosis@postgres.web3signer-gnosis.dappnode:5432/web3signer-gnosis",
     secondsPerSlot: 5,
     slotsPerEpoch: 16,
-    tlsCert: tlsCert(consensusClient)
+    tlsCert: tlsCert(consensusClient, Network.Gnosis)
   };
 };

--- a/packages/brain/src/modules/config/networks/holesky.ts
+++ b/packages/brain/src/modules/config/networks/holesky.ts
@@ -28,6 +28,6 @@ export const holeskyBrainConfig = (
     postgresUrl: "postgres://postgres:password@postgres.web3signer-holesky.dappnode:5432/web3signer",
     secondsPerSlot: 12,
     slotsPerEpoch: 32,
-    tlsCert: tlsCert(consensusClient)
+    tlsCert: tlsCert(consensusClient, Network.Holesky)
   };
 };

--- a/packages/brain/src/modules/config/networks/lukso.ts
+++ b/packages/brain/src/modules/config/networks/lukso.ts
@@ -28,6 +28,6 @@ export const luksoBrainConfig = (
     postgresUrl: "postgres://postgres:password@postgres.web3signer-lukso.dappnode:5432/web3signer",
     secondsPerSlot: 12,
     slotsPerEpoch: 32,
-    tlsCert: tlsCert(consensusClient)
+    tlsCert: tlsCert(consensusClient, Network.Lukso)
   };
 };

--- a/packages/brain/src/modules/config/networks/mainnet.ts
+++ b/packages/brain/src/modules/config/networks/mainnet.ts
@@ -28,6 +28,6 @@ export const mainnetBrainConfig = (
     postgresUrl: "postgres://postgres:mainnet@postgres.web3signer.dappnode:5432/web3signer-mainnet",
     secondsPerSlot: 12,
     slotsPerEpoch: 32,
-    tlsCert: tlsCert(consensusClient)
+    tlsCert: tlsCert(consensusClient, Network.Mainnet)
   };
 };

--- a/packages/brain/src/modules/config/networks/prater.ts
+++ b/packages/brain/src/modules/config/networks/prater.ts
@@ -28,6 +28,6 @@ export const praterBrainConfig = (
     postgresUrl: "postgres://postgres:password@postgres.web3signer-prater.dappnode:5432/web3signer",
     secondsPerSlot: 12,
     slotsPerEpoch: 32,
-    tlsCert: tlsCert(consensusClient)
+    tlsCert: tlsCert(consensusClient, Network.Prater)
   };
 };

--- a/packages/brain/src/modules/config/networks/tlsCert.ts
+++ b/packages/brain/src/modules/config/networks/tlsCert.ts
@@ -1,8 +1,8 @@
-import { ConsensusClient } from "@stakingbrain/common";
+import { ConsensusClient, Network } from "@stakingbrain/common";
 import fs from "fs";
 import path from "path";
 
-export const tlsCert = (consensusClient: ConsensusClient): Buffer | null => {
+export const tlsCert = (consensusClient: ConsensusClient, network: Network): Buffer | null => {
   if (consensusClient !== ConsensusClient.Teku) return null;
-  return fs.readFileSync(path.join("tls", "mainnet", "teku_client_keystore.p12"));
+  return fs.readFileSync(path.join("tls", network, "teku_client_keystore.p12"));
 };


### PR DESCRIPTION
Fix tls certificate for teku validator API. It was missing the network as string when resolvin the path of the tls certificate