### PR TITLE
Split config brain and config network

### DIFF
--- a/packages/brain/src/modules/config/getTlsCert.ts
+++ b/packages/brain/src/modules/config/getTlsCert.ts
@@ -2,7 +2,7 @@ import { ConsensusClient, Network } from "@stakingbrain/common";
 import fs from "fs";
 import path from "path";
 
-export const tlsCert = (consensusClient: ConsensusClient, network: Network): Buffer | null => {
+export const getTlsCert = (consensusClient: ConsensusClient, network: Network): Buffer | null => {
   if (consensusClient !== ConsensusClient.Teku) return null;
   return fs.readFileSync(path.join("tls", network, "teku_client_keystore.p12"));
 };

--- a/packages/brain/src/modules/config/getValidatorToken.ts
+++ b/packages/brain/src/modules/config/getValidatorToken.ts
@@ -1,6 +1,6 @@
 import { ConsensusClient } from "@stakingbrain/common";
 
-export const validatorToken = (consensusClient: ConsensusClient): string => {
+export const getValidatorToken = (consensusClient: ConsensusClient): string => {
   if (consensusClient === ConsensusClient.Teku) return "cd4892ca35d2f5d3e2301a65fc7aa660";
   if (consensusClient === ConsensusClient.Lighthouse)
     return "api-token-0x0200e6ce18e26fd38caca7ae1bfb9e2bba7efb20ed2746ad17f2f6dda44603152d";

--- a/packages/brain/src/modules/config/index.ts
+++ b/packages/brain/src/modules/config/index.ts
@@ -1,28 +1,44 @@
 import { Network } from "@stakingbrain/common";
 import { loadEnvs } from "./loadEnvs.js";
 import { BrainConfig } from "./types.js";
-import {
-  gnosisBrainConfig,
-  holeskyBrainConfig,
-  luksoBrainConfig,
-  mainnetBrainConfig,
-  praterBrainConfig
-} from "./networks/index.js";
+import { networkConfig } from "./networks/index.js";
+import { getValidatorToken } from "./getValidatorToken.js";
+import { getTlsCert } from "./getTlsCert.js";
 
 export const brainConfig = (): BrainConfig => {
   const { network, executionClient, consensusClient, isMevBoostSet, shareDataWithDappnode } = loadEnvs();
+
+  return {
+    network,
+    executionClient,
+    consensusClient,
+    isMevBoostSet,
+    executionClientUrl: `http://execution.${network}.dncore.dappnode:8545`,
+    validatorUrl: `${consensusClient === "teku" ? "https://validator.teku-holesky.dappnode:3500" : `http://validator.${network}.dncore.dappnode:3500`}`,
+    beaconchainUrl: `http:/beacon-chain.${network}.dncore.dappnode:3500`,
+    signerUrl: `http://signer.${network}.dncore.dappnode:9000`,
+    token: getValidatorToken(consensusClient),
+    host: network === "mainnet" ? `brain.web3signer.dappnode` : `brain.web3signer-${network}.dappnode`,
+    shareDataWithDappnode,
+    validatorsMonitorUrl: `http://validators-monitor.${network}.dncore.dappnode:3000`,
+    shareCronInterval: 24 * 60 * 60 * 1000, // 24 hours
+    postgresUrl: getPostgresUrl(network),
+    tlsCert: getTlsCert(consensusClient, network), // To avoid Teku edge case it is necessary to update TLS certificate in both: validator and brain
+    ...networkConfig(network)
+  };
+};
+
+const getPostgresUrl = (network: Network): string => {
   switch (network) {
     case Network.Holesky:
-      return holeskyBrainConfig(executionClient, consensusClient, isMevBoostSet, shareDataWithDappnode);
+      return "postgres://postgres:password@postgres.web3signer-holesky.dappnode:5432/web3signer";
     case Network.Mainnet:
-      return mainnetBrainConfig(executionClient, consensusClient, isMevBoostSet, shareDataWithDappnode);
+      return "postgres://postgres:mainnet@postgres.web3signer.dappnode:5432/web3signer-mainnet";
     case Network.Gnosis:
-      return gnosisBrainConfig(executionClient, consensusClient, isMevBoostSet, shareDataWithDappnode);
+      return "postgres://postgres:gnosis@postgres.web3signer-gnosis.dappnode:5432/web3signer-gnosis";
     case Network.Lukso:
-      return luksoBrainConfig(executionClient, consensusClient, isMevBoostSet, shareDataWithDappnode);
+      return "postgres://postgres:password@postgres.web3signer-lukso.dappnode:5432/web3signer";
     case Network.Prater:
-      return praterBrainConfig(executionClient, consensusClient, isMevBoostSet, shareDataWithDappnode);
-    default:
-      throw Error(`Network ${network} is not supported`);
+      return "postgres://postgres:password@postgres.web3signer-prater.dappnode:5432/web3signer";
   }
 };

--- a/packages/brain/src/modules/config/networks/gnosis.ts
+++ b/packages/brain/src/modules/config/networks/gnosis.ts
@@ -1,33 +1,10 @@
-import { ConsensusClient, ExecutionClient, Network } from "@stakingbrain/common";
-import { BrainConfig } from "../types.js";
-import { tlsCert } from "./tlsCert.js";
-import { validatorToken } from "./validatorToken.js";
+import type { NetworkConfig } from "../types.js";
 
-export const gnosisBrainConfig = (
-  executionClient: ExecutionClient,
-  consensusClient: ConsensusClient,
-  isMevBoostSet: boolean,
-  shareDataWithDappnode: boolean
-): BrainConfig => {
+export const gnosisBrainConfig = (): NetworkConfig => {
   return {
-    network: Network.Gnosis,
-    executionClient,
-    consensusClient,
-    isMevBoostSet,
-    executionClientUrl: "http://execution.gnosis.dncore.dappnode:8545",
-    validatorUrl: `${consensusClient === "teku" ? "https" : "http"}://validator.gnosis.dncore.dappnode:3500`,
-    beaconchainUrl: "http:/beacon-chain.gnosis.dncore.dappnode:3500",
     blockExplorerUrl: "https://gnosischa.in",
-    signerUrl: "http://web3signer.web3signer-gnosis.dappnode:9000",
-    token: validatorToken(consensusClient),
-    host: "brain.web3signer-gnosis.dappnode",
-    shareDataWithDappnode,
-    validatorsMonitorUrl: "https://validators-proofs.dappnode.io",
-    shareCronInterval: 24 * 60 * 60 * 1000, // 1 day in ms
     minGenesisTime: 1638968400, // Dec 8, 2021, 13:00 UTC
-    postgresUrl: "postgres://postgres:gnosis@postgres.web3signer-gnosis.dappnode:5432/web3signer-gnosis",
     secondsPerSlot: 5,
-    slotsPerEpoch: 16,
-    tlsCert: tlsCert(consensusClient, Network.Gnosis)
+    slotsPerEpoch: 16
   };
 };

--- a/packages/brain/src/modules/config/networks/holesky.ts
+++ b/packages/brain/src/modules/config/networks/holesky.ts
@@ -1,33 +1,10 @@
-import { ConsensusClient, ExecutionClient, Network } from "@stakingbrain/common";
-import { BrainConfig } from "../types.js";
-import { tlsCert } from "./tlsCert.js";
-import { validatorToken } from "./validatorToken.js";
+import type { NetworkConfig } from "../types.js";
 
-export const holeskyBrainConfig = (
-  executionClient: ExecutionClient,
-  consensusClient: ConsensusClient,
-  isMevBoostSet: boolean,
-  shareDataWithDappnode: boolean
-): BrainConfig => {
+export const holeskyBrainConfig = (): NetworkConfig => {
   return {
-    network: Network.Holesky,
-    executionClient,
-    consensusClient,
-    isMevBoostSet,
-    executionClientUrl: "http://execution.holesky.dncore.dappnode:8545",
-    validatorUrl: `${consensusClient === "teku" ? "https" : "http"}://validator.holesky.dncore.dappnode:3500`,
-    beaconchainUrl: "http:/beacon-chain.holesky.dncore.dappnode:3500",
     blockExplorerUrl: "https://holesky.beaconcha.in",
-    signerUrl: "http://web3signer.web3signer-holesky.dappnode:9000",
-    token: validatorToken(consensusClient),
-    host: "brain.web3signer-holesky.dappnode",
-    shareDataWithDappnode,
-    validatorsMonitorUrl: "https://validators-proofs.dappnode.io",
-    shareCronInterval: 24 * 60 * 60 * 1000, // 1 day in ms
     minGenesisTime: 1695902100, // Sep-28-2023 11:55:00 +UTC
-    postgresUrl: "postgres://postgres:password@postgres.web3signer-holesky.dappnode:5432/web3signer",
     secondsPerSlot: 12,
-    slotsPerEpoch: 32,
-    tlsCert: tlsCert(consensusClient, Network.Holesky)
+    slotsPerEpoch: 32
   };
 };

--- a/packages/brain/src/modules/config/networks/index.ts
+++ b/packages/brain/src/modules/config/networks/index.ts
@@ -1,5 +1,24 @@
-export { gnosisBrainConfig } from "./gnosis.js";
-export { holeskyBrainConfig } from "./holesky.js";
-export { luksoBrainConfig } from "./lukso.js";
-export { mainnetBrainConfig } from "./mainnet.js";
-export { praterBrainConfig } from "./prater.js";
+import { gnosisBrainConfig } from "./gnosis.js";
+import { holeskyBrainConfig } from "./holesky.js";
+import { luksoBrainConfig } from "./lukso.js";
+import { mainnetBrainConfig } from "./mainnet.js";
+import { praterBrainConfig } from "./prater.js";
+import type { NetworkConfig } from "../types.js";
+import { Network } from "@stakingbrain/common";
+
+export const networkConfig = (network: Network): NetworkConfig => {
+  switch (network) {
+    case Network.Holesky:
+      return holeskyBrainConfig();
+    case Network.Mainnet:
+      return mainnetBrainConfig();
+    case Network.Gnosis:
+      return gnosisBrainConfig();
+    case Network.Lukso:
+      return luksoBrainConfig();
+    case Network.Prater:
+      return praterBrainConfig();
+    default:
+      throw Error(`Network ${network} is not supported`);
+  }
+};

--- a/packages/brain/src/modules/config/networks/lukso.ts
+++ b/packages/brain/src/modules/config/networks/lukso.ts
@@ -1,33 +1,10 @@
-import { ConsensusClient, ExecutionClient, Network } from "@stakingbrain/common";
-import { BrainConfig } from "../types.js";
-import { tlsCert } from "./tlsCert.js";
-import { validatorToken } from "./validatorToken.js";
+import type { NetworkConfig } from "../types.js";
 
-export const luksoBrainConfig = (
-  executionClient: ExecutionClient,
-  consensusClient: ConsensusClient,
-  isMevBoostSet: boolean,
-  shareDataWithDappnode: boolean
-): BrainConfig => {
+export const luksoBrainConfig = (): NetworkConfig => {
   return {
-    network: Network.Lukso,
-    executionClient,
-    consensusClient,
-    isMevBoostSet,
-    executionClientUrl: "http://execution.lukso.dncore.dappnode:8545",
-    validatorUrl: `${consensusClient === "teku" ? "https" : "http"}://validator.lukso.dncore.dappnode:3500`,
-    beaconchainUrl: "http:/beacon-chain.lukso.dncore.dappnode:3500",
     blockExplorerUrl: "https://explorer.consensus.mainnet.lukso.network/",
-    signerUrl: "http://web3signer.web3signer-lukso.dappnode:9000",
-    token: validatorToken(consensusClient),
-    host: "brain.web3signer-lukso.dappnode",
-    shareDataWithDappnode,
-    validatorsMonitorUrl: "https://validators-proofs.dappnode.io",
-    shareCronInterval: 24 * 60 * 60 * 1000, // 1 day in ms
     minGenesisTime: 1684856400, // Tuesday, 23 May 2023 15:40:00 GMT
-    postgresUrl: "postgres://postgres:password@postgres.web3signer-lukso.dappnode:5432/web3signer",
     secondsPerSlot: 12,
-    slotsPerEpoch: 32,
-    tlsCert: tlsCert(consensusClient, Network.Lukso)
+    slotsPerEpoch: 32
   };
 };

--- a/packages/brain/src/modules/config/networks/mainnet.ts
+++ b/packages/brain/src/modules/config/networks/mainnet.ts
@@ -1,33 +1,10 @@
-import { ConsensusClient, ExecutionClient, Network } from "@stakingbrain/common";
-import { BrainConfig } from "../types.js";
-import { tlsCert } from "./tlsCert.js";
-import { validatorToken } from "./validatorToken.js";
+import type { NetworkConfig } from "../types.js";
 
-export const mainnetBrainConfig = (
-  executionClient: ExecutionClient,
-  consensusClient: ConsensusClient,
-  isMevBoostSet: boolean,
-  shareDataWithDappnode: boolean
-): BrainConfig => {
+export const mainnetBrainConfig = (): NetworkConfig => {
   return {
-    network: Network.Mainnet,
-    executionClient,
-    consensusClient,
-    isMevBoostSet,
-    executionClientUrl: "http://execution.mainnet.dncore.dappnode:8545",
-    validatorUrl: `${consensusClient === "teku" ? "https" : "http"}://validator.mainnet.dncore.dappnode:3500`,
-    beaconchainUrl: "http:/beacon-chain.mainnet.dncore.dappnode:3500",
     blockExplorerUrl: "https://beaconcha.in",
-    signerUrl: "http://web3signer.web3signer.dappnode:9000",
-    token: validatorToken(consensusClient),
-    host: "brain.web3signer.dappnode",
-    shareDataWithDappnode,
-    validatorsMonitorUrl: "https://validators-proofs.dappnode.io",
-    shareCronInterval: 24 * 60 * 60 * 1000, // 1 day in ms
     minGenesisTime: 1606824000,
-    postgresUrl: "postgres://postgres:mainnet@postgres.web3signer.dappnode:5432/web3signer-mainnet",
     secondsPerSlot: 12,
-    slotsPerEpoch: 32,
-    tlsCert: tlsCert(consensusClient, Network.Mainnet)
+    slotsPerEpoch: 32
   };
 };

--- a/packages/brain/src/modules/config/networks/prater.ts
+++ b/packages/brain/src/modules/config/networks/prater.ts
@@ -1,33 +1,10 @@
-import { ConsensusClient, ExecutionClient, Network } from "@stakingbrain/common";
-import { BrainConfig } from "../types.js";
-import { tlsCert } from "./tlsCert.js";
-import { validatorToken } from "./validatorToken.js";
+import type { NetworkConfig } from "../types.js";
 
-export const praterBrainConfig = (
-  executionClient: ExecutionClient,
-  consensusClient: ConsensusClient,
-  isMevBoostSet: boolean,
-  shareDataWithDappnode: boolean
-): BrainConfig => {
+export const praterBrainConfig = (): NetworkConfig => {
   return {
-    network: Network.Prater,
-    executionClient,
-    consensusClient,
-    isMevBoostSet,
-    executionClientUrl: "http://execution.prater.dncore.dappnode:8545",
-    validatorUrl: `${consensusClient === "teku" ? "https" : "http"}://validator.prater.dncore.dappnode:3500`,
-    beaconchainUrl: "http:/beacon-chain.prater.dncore.dappnode:3500",
     blockExplorerUrl: "https://prater.beaconcha.in",
-    signerUrl: "http://web3signer.web3signer-prater.dappnode:9000",
-    token: validatorToken(consensusClient),
-    host: "brain.web3signer-prater.dappnode",
-    shareDataWithDappnode,
-    validatorsMonitorUrl: "https://validators-proofs.dappnode.io",
-    shareCronInterval: 24 * 60 * 60 * 1000, // 1 day in ms
     minGenesisTime: 1614588812, // Mar-01-2021 08:53:32 AM +UTC
-    postgresUrl: "postgres://postgres:password@postgres.web3signer-prater.dappnode:5432/web3signer",
     secondsPerSlot: 12,
-    slotsPerEpoch: 32,
-    tlsCert: tlsCert(consensusClient, Network.Prater)
+    slotsPerEpoch: 32
   };
 };

--- a/packages/brain/src/modules/config/types.ts
+++ b/packages/brain/src/modules/config/types.ts
@@ -1,6 +1,6 @@
 import { ConsensusClient, ExecutionClient, Network } from "@stakingbrain/common";
 
-export interface BrainConfig {
+export interface BrainConfig extends NetworkConfig {
   network: Network;
   executionClient: ExecutionClient;
   consensusClient: ConsensusClient;
@@ -8,16 +8,19 @@ export interface BrainConfig {
   executionClientUrl: string;
   validatorUrl: string;
   beaconchainUrl: string;
-  blockExplorerUrl: string;
   signerUrl: string;
   token: string;
   host: string;
   shareDataWithDappnode: boolean;
   validatorsMonitorUrl: string;
   shareCronInterval: number;
-  minGenesisTime: number;
   postgresUrl: string;
+  tlsCert: Buffer | null;
+}
+
+export interface NetworkConfig {
+  minGenesisTime: number;
   secondsPerSlot: number;
   slotsPerEpoch: number;
-  tlsCert: Buffer | null;
+  blockExplorerUrl: string;
 }


### PR DESCRIPTION
Split the configuration of the bain from the configuration for each network.

Also fix the Teku validator URL since it cannot be used the fullnodea alias due to the certificate. It is required to update the certificate in both: validator teku and brain, at the same time