### PR TITLE
Get epoch finalized from finality checkpoint endpoint

### DIFF
--- a/packages/brain/src/modules/cron/trackValidatorsPerformance/trackValidatorsPerformance.ts
+++ b/packages/brain/src/modules/cron/trackValidatorsPerformance/trackValidatorsPerformance.ts
@@ -26,7 +26,14 @@ export async function trackValidatorsPerformanceCron({
   consensusClient: ConsensusClient;
 }): Promise<void> {
   try {
-    const currentEpoch = await beaconchainApi.getEpochHeader({ blockId: "finalized" });
+    const currentEpoch = parseInt(
+      (
+        await beaconchainApi.getStateFinalityCheckpoints({
+          stateId: "finalized"
+        })
+      ).data.finalized.epoch
+    );
+    // TODO: what if finalized is false
 
     if (currentEpoch !== lastProcessedEpoch) {
       await fetchAndInsertPerformanceCron({


### PR DESCRIPTION
Get epoch finalized from finality checkpoint endpoint ( `finality_checkpoints`) instead of from headers endpoint 