### PR TITLE
Store `trackValidatorsPerformance`error in db 

### DIFF
--- a/packages/brain/src/modules/apiClients/beaconchain/error.ts
+++ b/packages/brain/src/modules/apiClients/beaconchain/error.ts
@@ -3,6 +3,6 @@ import { ApiError } from "../error.js";
 export class BeaconchainApiError extends ApiError {
   constructor(message: string) {
     super(message);
-    this.name = "BeaconchainApiError"; // Override the name if needed
+    this.name = "BeaconchainApiError";
   }
 }

--- a/packages/brain/src/modules/apiClients/postgres/types.ts
+++ b/packages/brain/src/modules/apiClients/postgres/types.ts
@@ -21,10 +21,25 @@ export interface ValidatorPerformance {
   epoch: number;
   executionClient: ExecutionClient;
   consensusClient: ConsensusClient;
-  blockProposalStatus: BlockProposalStatus;
-  attestationsTotalRewards: AttestationsTotalRewards;
+  blockProposalStatus?: BlockProposalStatus;
+  attestationsTotalRewards?: AttestationsTotalRewards;
   slot?: number;
   liveness?: boolean;
   syncCommitteeRewards?: number;
-  error?: string;
+  error?: ValidatorPerformanceError;
+}
+
+export enum ValidatorPerformanceErrorCode {
+  BEACONCHAIN_API_ERROR = "BEACONCHAIN_API_ERROR",
+  EXECUTION_OFFLINE = "EXECUTION_OFFLINE",
+  CONSENSUS_SYNCING = "CONSENSUS_SYNCING",
+  BRAINDDB_ERROR = "BRAINDDB_ERROR",
+  MISSING_BLOCK_DATA = "MISSING_BLOCK_DATA",
+  MISSING_ATT_DATA = "MISSING_ATT_DATA",
+  UNKNOWN_ERROR = "UNKNOWN_ERROR"
+}
+
+export interface ValidatorPerformanceError {
+  code: ValidatorPerformanceErrorCode;
+  message: string;
 }

--- a/packages/brain/src/modules/cron/trackValidatorsPerformance/error.ts
+++ b/packages/brain/src/modules/cron/trackValidatorsPerformance/error.ts
@@ -1,0 +1,22 @@
+import { CronError } from "../error.js";
+
+export class TrackValidatorPerformanceCronError extends CronError {
+  constructor(message: string) {
+    super(message);
+    this.name = "TrackValidatorPerformanceCronError";
+  }
+}
+
+export class NodeSyncingError extends TrackValidatorPerformanceCronError {
+  constructor(message: string) {
+    super(message);
+    this.name = "NodeSyncingError";
+  }
+}
+
+export class ExecutionOfflineError extends TrackValidatorPerformanceCronError {
+  constructor(message: string) {
+    super(message);
+    this.name = "ExecutionOfflineError";
+  }
+}

--- a/packages/brain/src/modules/cron/trackValidatorsPerformance/trackValidatorsPerformance.ts
+++ b/packages/brain/src/modules/cron/trackValidatorsPerformance/trackValidatorsPerformance.ts
@@ -2,15 +2,20 @@ import { BeaconchainApi } from "../../apiClients/beaconchain/index.js";
 import { PostgresClient } from "../../apiClients/postgres/index.js";
 import logger from "../../logger/index.js";
 import { BrainDataBase } from "../../db/index.js";
-import { insertPerformanceDataNotThrow } from "./insertPerformanceData.js";
+import { insertPerformanceData } from "./insertPerformanceData.js";
 import { getAttestationsTotalRewards } from "./getAttestationsTotalRewards.js";
 import { getBlockProposalStatusMap } from "./getBlockProposalStatusMap.js";
 import { getActiveValidatorsLoadedInBrain } from "./getActiveValidatorsLoadedInBrain.js";
 import { logPrefix } from "./logPrefix.js";
 import { ConsensusClient, ExecutionClient } from "@stakingbrain/common";
 import { TotalRewards } from "../../apiClients/types.js";
+import { ValidatorPerformanceError, ValidatorPerformanceErrorCode } from "../../apiClients/postgres/types.js";
+import { BeaconchainApiError } from "../../apiClients/beaconchain/error.js";
+import { BrainDbError } from "../../db/error.js";
+import { ExecutionOfflineError, NodeSyncingError } from "./error.js";
 
 let lastProcessedEpoch: number | undefined = undefined;
+let lastEpochProcessedWithError = false;
 
 export async function trackValidatorsPerformanceCron({
   brainDb,
@@ -28,7 +33,9 @@ export async function trackValidatorsPerformanceCron({
   try {
     const currentEpoch = await beaconchainApi.getEpochHeader({ blockId: "finalized" });
 
-    if (currentEpoch !== lastProcessedEpoch) {
+    // If the current epoch is different from the last processed epoch, or epoch is the same but the last epoch was processed with an error
+    // then fetch and insert the performance data
+    if (currentEpoch !== lastProcessedEpoch || lastEpochProcessedWithError) {
       await fetchAndInsertPerformanceCron({
         brainDb,
         postgresClient,
@@ -59,27 +66,27 @@ export async function fetchAndInsertPerformanceCron({
   consensusClient: ConsensusClient;
   currentEpoch: number;
 }): Promise<void> {
-  let errorDetails: Error | undefined = undefined;
+  let validatorPerformanceError: ValidatorPerformanceError | undefined;
   let activeValidatorsIndexes: string[] = [];
   let validatorBlockStatusMap = new Map();
   let validatorsAttestationsTotalRewards: TotalRewards[] = [];
 
   try {
     logger.debug(`${logPrefix}Starting to track performance for epoch: ${currentEpoch}`);
-    activeValidatorsIndexes = await getActiveValidatorsLoadedInBrain({ beaconchainApi, brainDb });
-    if (activeValidatorsIndexes.length === 0) {
-      logger.info(`${logPrefix}No active validators found`);
-      return; // Exit if no active validators are found
+    try {
+      activeValidatorsIndexes = await getActiveValidatorsLoadedInBrain({ beaconchainApi, brainDb });
+      if (activeValidatorsIndexes.length === 0) {
+        logger.info(`${logPrefix}No active validators found`);
+        return; // Exit if no active validators are found
+      }
+    } catch (e) {
+      logger.error(`${logPrefix}Error getting active validators: ${e}`);
+      return; // active validator indexes is crutial for the error handling since each error is indexed by the validator index
     }
 
     const { el_offline, is_syncing } = (await beaconchainApi.getSyncingStatus()).data;
-    if (is_syncing) {
-      logger.debug(`${logPrefix}Node is syncing, skipping epoch ${currentEpoch}`);
-      return; // Exit if the node is syncing. Head finalized will change
-    }
-    if (el_offline) {
-      throw new Error("EL Node offline"); // throw error and retry
-    }
+    if (is_syncing) throw new NodeSyncingError("Node is syncing");
+    if (el_offline) throw new ExecutionOfflineError("Execution layer is offline");
 
     validatorsAttestationsTotalRewards = await getAttestationsTotalRewards({
       beaconchainApi,
@@ -92,20 +99,52 @@ export async function fetchAndInsertPerformanceCron({
       epoch: currentEpoch.toString(),
       activeValidatorsIndexes
     });
+
+    validatorPerformanceError = undefined; // Reset error details
+    lastEpochProcessedWithError = false;
   } catch (e) {
     logger.error(`${logPrefix}Error tracking validator performance for epoch ${currentEpoch}: ${e}`);
-    errorDetails = e; // Capture the error message
+    validatorPerformanceError = getValidatorPerformanceError(e);
+
+    lastEpochProcessedWithError = true;
   } finally {
     // Always call storeData in the finally block, regardless of success or failure in try block
-    await insertPerformanceDataNotThrow({
+    await insertPerformanceData({
       postgresClient,
       activeValidatorsIndexes,
       currentEpoch,
       validatorBlockStatusMap,
       validatorsAttestationsTotalRewards,
-      error: errorDetails,
+      error: validatorPerformanceError,
       executionClient,
       consensusClient
     });
   }
+}
+
+function getValidatorPerformanceError(e: Error): ValidatorPerformanceError {
+  if (e instanceof BeaconchainApiError)
+    return {
+      code: ValidatorPerformanceErrorCode.EXECUTION_OFFLINE,
+      message: e.message
+    };
+  if (e instanceof BrainDbError)
+    return {
+      code: ValidatorPerformanceErrorCode.BRAINDDB_ERROR,
+      message: e.message
+    };
+  if (e instanceof ExecutionOfflineError)
+    return {
+      code: ValidatorPerformanceErrorCode.EXECUTION_OFFLINE,
+      message: e.message
+    };
+  if (e instanceof NodeSyncingError)
+    return {
+      code: ValidatorPerformanceErrorCode.CONSENSUS_SYNCING,
+      message: e.message
+    };
+  return {
+    code: ValidatorPerformanceErrorCode.UNKNOWN_ERROR,
+    message: e.message
+  };
 }

--- a/packages/brain/src/modules/validatorsDataIngest/getAttestationSuccessRate.ts
+++ b/packages/brain/src/modules/validatorsDataIngest/getAttestationSuccessRate.ts
@@ -29,9 +29,11 @@ export function getAttestationSuccessRate({
   }
 
   // Calculate the total successful attestations
-  const totalSuccessfulAttestations = validatorData.filter(
-    (data) => data.epoch >= startEpoch && data.epoch < endEpoch && parseInt(data.attestationsTotalRewards.source) >= 0
-  ).length;
+  const totalSuccessfulAttestations = validatorData.filter((data) => {
+    const attestationsTotalRewards = data.attestationsTotalRewards;
+    if (!attestationsTotalRewards) return false;
+    return data.epoch >= startEpoch && data.epoch < endEpoch && parseInt(attestationsTotalRewards.source) >= 0;
+  }).length;
 
   return Math.round((totalSuccessfulAttestations / totalAttestationOpportunities) * 100);
 }


### PR DESCRIPTION

Store `trackValidatorsPerformance`error in db:
- If the epoch was processed WITHOUT an error then skip cron iteration
- If the epoch was processed WITH an error the enter again cron iteration

The SQL query will only update on duplicated exception if there is no error. If there is an error then do not update row in db. Althought this last situation should never happen