### PR TITLE
Update Prysm 5.1.0 token

### DIFF
--- a/packages/brain/src/modules/config/getValidatorToken.ts
+++ b/packages/brain/src/modules/config/getValidatorToken.ts
@@ -5,7 +5,7 @@ export const getValidatorToken = (consensusClient: ConsensusClient): string => {
   if (consensusClient === ConsensusClient.Lighthouse)
     return "api-token-0x0200e6ce18e26fd38caca7ae1bfb9e2bba7efb20ed2746ad17f2f6dda44603152d";
   if (consensusClient === ConsensusClient.Prysm)
-    return "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.MxwOozSH-TLbW_XKepjyYDHm2IT8Ki0tD3AHuajfNMg";
+    return "0xd59b8238ecaeb255d62c85c6ca8aee185870bd7a27e43f85fd2658267036d94a";
   if (consensusClient === ConsensusClient.Nimbus)
     return "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.MxwOozSH-TLbW_XKepjyYDHm2IT8Ki0tD3AHuajfNMg";
   if (consensusClient === ConsensusClient.Lodestar)

--- a/packages/brain/test/unit/modules/apiClients/cron.unit.test.ts
+++ b/packages/brain/test/unit/modules/apiClients/cron.unit.test.ts
@@ -33,7 +33,7 @@ describe.skip("Cron: Prater", () => {
         containerName:
           "DAppNodePackage-validator.prysm-prater.dnp.dappnode.eth",
         token:
-          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.MxwOozSH-TLbW_XKepjyYDHm2IT8Ki0tD3AHuajfNMg",
+          "0xd59b8238ecaeb255d62c85c6ca8aee185870bd7a27e43f85fd2658267036d94a",
       },*/
       {
         name: "Lighthouse",

--- a/packages/brain/test/unit/modules/apiClients/validatorApi.unit.test.ts
+++ b/packages/brain/test/unit/modules/apiClients/validatorApi.unit.test.ts
@@ -19,7 +19,7 @@ describe.skip("Validator API: Prater", () => {
       {
         name: "Prysm",
         containerName: "DAppNodePackage-validator.prysm-prater.dnp.dappnode.eth",
-        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.MxwOozSH-TLbW_XKepjyYDHm2IT8Ki0tD3AHuajfNMg"
+        token: "0xd59b8238ecaeb255d62c85c6ca8aee185870bd7a27e43f85fd2658267036d94a"
       }
       /**{
         name: "Lighthouse",

--- a/packages/brain/test/unit/modules/db/index.unit.test.ts
+++ b/packages/brain/test/unit/modules/db/index.unit.test.ts
@@ -77,7 +77,7 @@ describe("DataBase", () => {
       const validatorApi = new ValidatorApi(
         {
           baseUrl: `http://${consensusIp}:3500`,
-          authToken: `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.MxwOozSH-TLbW_XKepjyYDHm2IT8Ki0tD3AHuajfNMg`
+          authToken: `0xd59b8238ecaeb255d62c85c6ca8aee185870bd7a27e43f85fd2658267036d94a`
         },
         Network.Prater
       );


### PR DESCRIPTION
Update Prysm validator API token for v5.1.0 which requires a token that follows a defined standard, not complied by the current one. Needs to be released together with: https://github.com/dappnode/DAppNodePackage-prysm-generic/pull/7