### PR TITLE
improve fetching indexes from beaconchainapi

### DIFF
--- a/packages/brain/src/modules/apiClients/beaconchain/index.ts
+++ b/packages/brain/src/modules/apiClients/beaconchain/index.ts
@@ -144,7 +144,7 @@ export class BeaconchainApi extends StandardApi {
   }): Promise<BeaconchainValidatorFromStateGetResponse> {
     try {
       return await this.request({
-        method: "POST",
+        method: "GET",
         endpoint: path.join(this.beaconchainEndpoint, "states", state, "validators", pubkey)
       });
     } catch (e) {

--- a/packages/brain/src/modules/cron/trackValidatorsPerformance/getActiveValidatorsLoadedInBrain.ts
+++ b/packages/brain/src/modules/cron/trackValidatorsPerformance/getActiveValidatorsLoadedInBrain.ts
@@ -77,7 +77,7 @@ async function getValidatorIndexesAndSaveInDb({
       const { pubkey } = validatorData.validator;
       const index = validatorData.index;
       validatorIndexes.push(index);
-      brainDb.updateValidators({ validators: { [pubkey]: { ...brainDbData[pubkey], index: parseInt(index) } } } );
+      brainDb.updateValidators({ validators: { [pubkey]: { ...brainDbData[pubkey], index: parseInt(index) } } });
     }
   }
 

--- a/packages/brain/src/modules/cron/trackValidatorsPerformance/getActiveValidatorsLoadedInBrain.ts
+++ b/packages/brain/src/modules/cron/trackValidatorsPerformance/getActiveValidatorsLoadedInBrain.ts
@@ -6,9 +6,8 @@ import logger from "../../logger/index.js";
 import { logPrefix } from "./logPrefix.js";
 
 /**
- * Get the active validators from the beaconchain API. To do so it will get the validator indexes from the brain db,
- * if there are no indexes, it will get them from the beaconchain API and update the brain db with the indexes for further
- * use.
+ * Get the active validators from the beaconchain API. To do so, it will get the validator indexes from the brain db.
+ * If there are no indexes, it will get them from the beaconchain API and update the brain db with the indexes for further use.
  *
  * @param {BeaconchainApi} beaconchainApi - Beaconchain API client.
  * @param {BrainDataBase} brainDb - Brain DB client.
@@ -23,15 +22,15 @@ export async function getActiveValidatorsLoadedInBrain({
 }): Promise<string[]> {
   const validatorIndexes = await getValidatorIndexesAndSaveInDb({ beaconchainApi, brainDb });
   if (validatorIndexes.length === 0) return [];
-  return (
-    await beaconchainApi.postStateValidators({
-      body: {
-        ids: validatorIndexes,
-        statuses: [ValidatorStatus.ACTIVE_ONGOING]
-      },
-      stateId: "finalized"
-    })
-  ).data.map((validator) => validator.index.toString());
+  const response = await beaconchainApi.postStateValidators({
+    body: {
+      ids: validatorIndexes,
+      statuses: [ValidatorStatus.ACTIVE_ONGOING]
+    },
+    stateId: "finalized"
+  });
+
+  return response.data.map((validator) => validator.index.toString());
 }
 
 /**
@@ -52,24 +51,34 @@ async function getValidatorIndexesAndSaveInDb({
   const brainDbData = brainDb.getData();
   if (isEmpty(brainDbData)) return [];
 
-  // get validator indexes from brain db
+  // Get validator indexes from brain db
   const validatorIndexes: string[] = [];
   const validatorPubkeysWithNoIndex: string[] = [];
-  // iterate over brain db data and push the indexes to the array
+  // Iterate over brain db data and push the indexes to the array
   for (const [pubkey, details] of Object.entries(brainDbData)) {
     if (details.index) validatorIndexes.push(details.index.toString());
     else validatorPubkeysWithNoIndex.push(pubkey);
   }
 
+  // If there are validators with no index, fetch them in batch from the beaconchain API
   if (validatorPubkeysWithNoIndex.length > 0) {
     logger.debug(`${logPrefix}Getting validator indexes from pubkeys`);
-    await Promise.all(
-      validatorPubkeysWithNoIndex.map(async (pubkey) => {
-        const index = (await beaconchainApi.getStateValidator({ state: "finalized", pubkey })).data.index;
-        validatorIndexes.push(index);
-        brainDb.updateValidators({ validators: { [pubkey]: { ...brainDbData[pubkey], index: parseInt(index) } } });
-      })
-    );
+
+    const response = await beaconchainApi.postStateValidators({
+      stateId: "finalized",
+      body: {
+        ids: validatorPubkeysWithNoIndex,
+        statuses: []
+      }
+    });
+
+    // Update the brain DB with fetched indexes and add them to the array
+    for (const validatorData of response.data) {
+      const { pubkey } = validatorData.validator;
+      const index = validatorData.index;
+      validatorIndexes.push(index);
+      brainDb.updateValidators({ validators: { [pubkey]: { ...brainDbData[pubkey], index: parseInt(index) } } } );
+    }
   }
 
   return validatorIndexes;

--- a/packages/brain/test/unit/modules/ cron/trackValidatorsPerformance/getActiveValidatorsLoadedInBrain.unit.test.ts
+++ b/packages/brain/test/unit/modules/ cron/trackValidatorsPerformance/getActiveValidatorsLoadedInBrain.unit.test.ts
@@ -11,6 +11,17 @@ import { StakingBrainDb } from "../../../../../src/modules/db/types.js";
 import { getActiveValidatorsLoadedInBrain } from "../../../../../src/modules/cron/trackValidatorsPerformance/getActiveValidatorsLoadedInBrain.js";
 import { Network } from "@stakingbrain/common";
 
+const validators: { pubkey: string; index: number }[] = [
+  {
+    pubkey: "0x86531f35f71730767e72692442a2020a6f252c15bc73d11e201d658ed90dde0dd15d9614e6c115b2dd0221ce35dcdcb3",
+    index: 1802289
+  },
+  {
+    pubkey: "0x86531f35f71730767e72692442a2020a6f252c15bc73d11e201d658ed90dde0dd15d9614e6c115b2dd0221ce35dcdcb4",
+    index: 1802291
+  }
+];
+
 const validatorIndexOne = 1802289;
 const pubkeyOne = "0x86531f35f71730767e72692442a2020a6f252c15bc73d11e201d658ed90dde0dd15d9614e6c115b2dd0221ce35dcdcb3";
 const validatorIndexTwo = 1802291;
@@ -78,12 +89,12 @@ class BeaconchainApiMock extends BeaconchainApi {
     return {
       execution_optimistic: false,
       finalized: true,
-      data: body.ids.map((id) => ({
-        index: id,
+      data: validators.map((validator) => ({
+        index: validator.index.toString(),
         balance: "0",
         status: ValidatorStatus.ACTIVE_ONGOING,
         validator: {
-          pubkey: "",
+          pubkey: validator.pubkey,
           withdrawal_credentials: "",
           effective_balance: "",
           slashed: false,


### PR DESCRIPTION
- revert `getStateValidator` to being a GET again
- fetch all validator indexes from beaconchain instead of going one by one