### PR TITLE
Add prometheus client and collect metrics for notification

### DIFF
--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -7,7 +7,8 @@ import {
   BlockExplorerApi,
   ValidatorApi,
   DappnodeSignatureVerifier,
-  DappmanagerApi
+  DappmanagerApi,
+  PrometheusApi
 } from "./modules/apiClients/index.js";
 import { startUiServer, startLaunchpadApi } from "./modules/apiServers/index.js";
 import * as dotenv from "dotenv";
@@ -57,6 +58,13 @@ logger.debug(
 );
 
 // Create API instances. Must preceed db initialization
+export const prometheusApi = new PrometheusApi({
+  baseUrl: executionClientUrl,
+  minGenesisTime,
+  secondsPerSlot,
+  slotsPerEpoch,
+  network
+});
 export const signerApi = new Web3SignerApi(
   {
     baseUrl: signerUrl,
@@ -114,6 +122,7 @@ export const trackValidatorsPerformanceCronTask = new CronJob(
       beaconchainApi,
       executionClient,
       consensusClient,
+      prometheusApi,
       dappmanagerApi,
       sendNotification: true
     });

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -59,7 +59,7 @@ logger.debug(
 
 // Create API instances. Must preceed db initialization
 export const prometheusApi = new PrometheusApi({
-  baseUrl: executionClientUrl,
+  baseUrl: "http://prometheus.dms.dappnode:9090",
   minGenesisTime,
   secondsPerSlot,
   slotsPerEpoch,

--- a/packages/brain/src/modules/apiClients/index.ts
+++ b/packages/brain/src/modules/apiClients/index.ts
@@ -1,5 +1,6 @@
 export { BlockExplorerApi } from "./blockExplorer/index.js";
 export { DappmanagerApi } from "./dappmanager/index.js";
+export { PrometheusApi } from "./prometheus/index.js";
 export { BeaconchainApi } from "./beaconchain/index.js";
 export { ValidatorApi } from "./validator/index.js";
 export { StandardApi } from "./standard.js";

--- a/packages/brain/src/modules/apiClients/prometheus/error.ts
+++ b/packages/brain/src/modules/apiClients/prometheus/error.ts
@@ -1,0 +1,8 @@
+import { ApiError } from "../error.js";
+
+export class PrometheusApiError extends ApiError {
+  constructor(message: string) {
+    super(message);
+    this.name = "PrometheusApiError";
+  }
+}

--- a/packages/brain/src/modules/apiClients/prometheus/index.ts
+++ b/packages/brain/src/modules/apiClients/prometheus/index.ts
@@ -1,0 +1,166 @@
+import { Network } from "@stakingbrain/common";
+import logger from "../../logger/index.js";
+import { StandardApi } from "../standard.js";
+import { AvgHostMetrics } from "./types.js";
+
+export class PrometheusApi extends StandardApi {
+  private readonly minGenesisTime: number;
+  private readonly slotsPerEpoch: number;
+  private readonly secondsPerSlot: number;
+
+  constructor({
+    baseUrl,
+    minGenesisTime,
+    slotsPerEpoch,
+    secondsPerSlot,
+    network
+  }: {
+    baseUrl: string;
+    minGenesisTime: number;
+    slotsPerEpoch: number;
+    secondsPerSlot: number;
+    network: Network;
+  }) {
+    super({ baseUrl }, network);
+    this.minGenesisTime = minGenesisTime;
+    this.slotsPerEpoch = slotsPerEpoch;
+    this.secondsPerSlot = secondsPerSlot;
+  }
+
+  /**
+   * Get average host metrics for a given epoch:
+   * - avgCpuTemperature
+   * - avgCpuUsage
+   * - avgMemoryUsage
+   * - ioUtilizationPerDisk
+   */
+  public async getPrometheusMetrics({ epoch }: { epoch: number }): Promise<AvgHostMetrics> {
+    try {
+      const { startTimestamp, endTimestamp } = this.calculateEpochTimestamps(epoch);
+
+      // Looks like query_range does not allow to request multiple queries in a single reques
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const ioDisk: { metric: { device: string }; values: any[] }[] = await this.getPrometheusDataResult({
+        query: `irate(node_disk_io_time_seconds_total{instance="node-exporter.dms.dappnode:9100", job="nodeexporter"}[${endTimestamp - startTimestamp}s])`,
+        startTimestamp,
+        endTimestamp
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const ioUtilizationPerDisk = ioDisk.reduce((acc: { [key: string]: any }, disk) => {
+        const device = disk.metric.device;
+        const utilization = Math.round(parseFloat(disk.values[0][1]) * 100);
+        acc[device] = utilization;
+        return acc;
+      }, {});
+
+      return {
+        avgCpuTemperature: await this.getPrometheusAvgMetric({
+          query: `avg_over_time(dappmanager_cpu_temperature_celsius{app="dappmanager-custom-metrics", instance="dappmanager.dappnode:80", job="manager_sd", package="dappmanager.dnp.dappnode.eth", service="dappmanager", type="current"}[${endTimestamp - startTimestamp}s])`,
+          startTimestamp,
+          endTimestamp
+        }),
+        avgCpuUsage: await this.getPrometheusAvgMetric({
+          query: `100 * (1 - avg(rate(node_cpu_seconds_total{instance="node-exporter.dms.dappnode:9100", job="nodeexporter", mode="idle"}[${endTimestamp - startTimestamp}s])) by (instance))`,
+          startTimestamp,
+          endTimestamp
+        }),
+        avgMemoryUsage: await this.getPrometheusAvgMetric({
+          query: `100 * (1 - avg(node_memory_MemAvailable_bytes{instance="node-exporter.dms.dappnode:9100", job="nodeexporter"} / node_memory_MemTotal_bytes{instance="node-exporter.dms.dappnode:9100", job="nodeexporter"}) by (instance))`,
+          startTimestamp,
+          endTimestamp
+        }),
+        ioUtilizationPerDisk
+      };
+    } catch (error) {
+      logger.error("Failed to get prometheus metrics", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Query prometheus metric using the endpoint /api/v1/query_range.
+   * Used to get the data result for later processing.
+   *
+   * @see https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries
+   */
+  private async getPrometheusDataResult({
+    query,
+    startTimestamp,
+    endTimestamp
+  }: {
+    query: string;
+    startTimestamp: number;
+    endTimestamp: number;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }): Promise<{ metric: { device: string }; values: any[] }[]> {
+    // Construct the request body
+    const requestBody = new URLSearchParams({
+      query,
+      start: startTimestamp.toString(),
+      end: endTimestamp.toString(),
+      step: `10m` // It should be higher than the time range so it returns only one value
+    }).toString();
+
+    return (
+      await this.request({
+        method: "POST",
+        endpoint: `/api/v1/query_range`,
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded"
+        },
+        body: requestBody
+      })
+    ).data.result;
+  }
+
+  /**
+   * Query prometheus metric using the endpoint /api/v1/query_range.
+   * This method assumes there is only 1 metric in the reponse (in the array)
+   *
+   * @see https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries
+   */
+  private async getPrometheusAvgMetric({
+    query,
+    startTimestamp,
+    endTimestamp
+  }: {
+    query: string;
+    startTimestamp: number;
+    endTimestamp: number;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }): Promise<number> {
+    // Construct the request body
+    const requestBody = new URLSearchParams({
+      query,
+      start: startTimestamp.toString(),
+      end: endTimestamp.toString(),
+      step: `10m` // It should be higher than the time range so it returns only one value
+    }).toString();
+
+    return Math.round(
+      parseFloat(
+        (
+          await this.request({
+            method: "POST",
+            endpoint: `/api/v1/query_range`,
+            headers: {
+              "Content-Type": "application/x-www-form-urlencoded"
+            },
+            body: requestBody
+          })
+        ).data.result[0].values[0][1]
+      )
+    );
+  }
+
+  private calculateEpochTimestamps(epoch: number): { startTimestamp: number; endTimestamp: number } {
+    const startTimestamp = this.minGenesisTime + epoch * this.slotsPerEpoch * this.secondsPerSlot;
+    const endTimestamp = startTimestamp + this.slotsPerEpoch * this.secondsPerSlot - 1;
+    return {
+      startTimestamp,
+      endTimestamp
+    };
+  }
+}

--- a/packages/brain/src/modules/apiClients/prometheus/index.ts
+++ b/packages/brain/src/modules/apiClients/prometheus/index.ts
@@ -56,6 +56,8 @@ export class PrometheusApi extends StandardApi {
       }, {});
 
       return {
+        startTimestamp,
+        endTimestamp,
         avgCpuTemperature: await this.getPrometheusAvgMetric({
           query: `avg_over_time(dappmanager_cpu_temperature_celsius{app="dappmanager-custom-metrics", instance="dappmanager.dappnode:80", job="manager_sd", package="dappmanager.dnp.dappnode.eth", service="dappmanager", type="current"}[${endTimestamp - startTimestamp}s])`,
           startTimestamp,

--- a/packages/brain/src/modules/apiClients/prometheus/types.ts
+++ b/packages/brain/src/modules/apiClients/prometheus/types.ts
@@ -1,0 +1,8 @@
+export interface AvgHostMetrics {
+  avgCpuTemperature: number;
+  avgCpuUsage: number;
+  avgMemoryUsage: number;
+  ioUtilizationPerDisk: {
+    [disk: string]: number;
+  };
+}

--- a/packages/brain/src/modules/apiClients/prometheus/types.ts
+++ b/packages/brain/src/modules/apiClients/prometheus/types.ts
@@ -1,4 +1,6 @@
 export interface AvgHostMetrics {
+  startTimestamp: number;
+  endTimestamp: number;
   avgCpuTemperature: number;
   avgCpuUsage: number;
   avgMemoryUsage: number;

--- a/packages/brain/src/modules/apiClients/standard.ts
+++ b/packages/brain/src/modules/apiClients/standard.ts
@@ -128,9 +128,11 @@ export class StandardApi {
               }
             } else {
               let errorMessage = "";
+
               if (res.headers["content-type"] && res.headers["content-type"].includes("application/json")) {
                 try {
-                  errorMessage = JSON.parse(Buffer.concat(data).toString())?.message;
+                  // if its a error message in JSON we dont know the object format so print it in string format the whole error
+                  errorMessage = Buffer.concat(data).toString();
                 } catch (e) {
                   logger.error(
                     `Error parsing response from ${this.requestOptions.hostname} ${endpoint} ${e.message}`,

--- a/packages/brain/src/modules/cron/trackValidatorsPerformance/fetchAndInsertValidatorsPerformanceData.ts
+++ b/packages/brain/src/modules/cron/trackValidatorsPerformance/fetchAndInsertValidatorsPerformanceData.ts
@@ -17,7 +17,7 @@ import {
 import { BeaconchainApiError } from "../../apiClients/beaconchain/error.js";
 import { BrainDbError } from "../../db/error.js";
 import { ExecutionOfflineError, NodeSyncingError } from "./error.js";
-import { DappmanagerApi } from "../../apiClients/index.js";
+import { DappmanagerApi, PrometheusApi } from "../../apiClients/index.js";
 import { sendValidatorsPerformanceNotifications } from "./sendValidatorsPerformanceNotifications.js";
 
 let lastProcessedEpoch: number | undefined = undefined;
@@ -29,6 +29,7 @@ export async function fetchAndInsertValidatorsPerformanceData({
   executionClient,
   consensusClient,
   currentEpoch,
+  prometheusApi,
   dappmanagerApi,
   sendNotification
 }: {
@@ -38,6 +39,7 @@ export async function fetchAndInsertValidatorsPerformanceData({
   executionClient: ExecutionClient;
   consensusClient: ConsensusClient;
   currentEpoch: number;
+  prometheusApi: PrometheusApi;
   dappmanagerApi: DappmanagerApi;
   sendNotification: boolean;
 }): Promise<void> {
@@ -92,6 +94,7 @@ export async function fetchAndInsertValidatorsPerformanceData({
     // Send notifications if the last epoch was processed without an error
     if (sendNotification && !validatorPerformanceError)
       await sendValidatorsPerformanceNotifications({
+        prometheusApi,
         dappmanagerApi,
         currentEpoch: currentEpoch.toString(),
         validatorBlockStatusMap,

--- a/packages/brain/src/modules/cron/trackValidatorsPerformance/index.ts
+++ b/packages/brain/src/modules/cron/trackValidatorsPerformance/index.ts
@@ -1,5 +1,5 @@
 import { ExecutionClient, ConsensusClient } from "@stakingbrain/common";
-import { PostgresClient, BeaconchainApi, DappmanagerApi } from "../../apiClients/index.js";
+import { PostgresClient, BeaconchainApi, DappmanagerApi, PrometheusApi } from "../../apiClients/index.js";
 import { BrainDataBase } from "../../db/index.js";
 import logger from "../../logger/index.js";
 import { fetchAndInsertValidatorsPerformanceData } from "./fetchAndInsertValidatorsPerformanceData.js";
@@ -11,6 +11,7 @@ export async function trackValidatorsPerformanceCron({
   executionClient,
   consensusClient,
   dappmanagerApi,
+  prometheusApi,
   sendNotification
 }: {
   brainDb: BrainDataBase;
@@ -19,6 +20,7 @@ export async function trackValidatorsPerformanceCron({
   executionClient: ExecutionClient;
   consensusClient: ConsensusClient;
   dappmanagerApi: DappmanagerApi;
+  prometheusApi: PrometheusApi;
   sendNotification: boolean;
 }): Promise<void> {
   try {
@@ -39,6 +41,7 @@ export async function trackValidatorsPerformanceCron({
       executionClient,
       consensusClient,
       currentEpoch,
+      prometheusApi,
       dappmanagerApi,
       sendNotification
     });

--- a/packages/brain/src/modules/cron/trackValidatorsPerformance/sendValidatorsPerformanceNotifications.ts
+++ b/packages/brain/src/modules/cron/trackValidatorsPerformance/sendValidatorsPerformanceNotifications.ts
@@ -141,7 +141,11 @@ function getDmsDashboardsMessage({
   startTimestamp: number;
   endTimestamp: number;
 }): string {
+  // dashboard links must be with timestamps in milliseconds
+  // see https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/manage-dashboard-links/
+  const startTimestampInMs = startTimestamp * 1000;
+  const endTimestampInMs = endTimestamp * 1000;
   return `For more details, check the DMS dashboards:\n
-- [Host dashboard](http://dms.dappnode/d/dms-host/host?orgId=1&from=${startTimestamp}&to=${endTimestamp})
-- [Docker dashboard](http://dms.dappnode/d/dms-docker/docker?orgId=1&from=${startTimestamp}&to=${endTimestamp})`;
+- [Host dashboard](http://dms.dappnode/d/dms-host/host?orgId=1&from=${startTimestampInMs}&to=${endTimestampInMs})
+- [Docker dashboard](http://dms.dappnode/d/dms-docker/docker?orgId=1&from=${startTimestampInMs}&to=${endTimestampInMs})`;
 }

--- a/packages/brain/src/modules/cron/trackValidatorsPerformance/sendValidatorsPerformanceNotifications.ts
+++ b/packages/brain/src/modules/cron/trackValidatorsPerformance/sendValidatorsPerformanceNotifications.ts
@@ -119,18 +119,17 @@ async function getHostMetricsMessage(prometheusApi: PrometheusApi, epoch: string
   const { startTimestamp, endTimestamp, avgCpuTemperature, avgCpuUsage, avgMemoryUsage, ioUtilizationPerDisk } =
     await prometheusApi.getPrometheusMetrics({ epoch: parseInt(epoch) });
 
-  // create beautiful message for ioUtilizationPerDisk
+  // Create a formatted message for Disk I/O utilization
   const ioUtilizationPerDiskMessage = Object.entries(ioUtilizationPerDisk)
-    .map(([disk, utilization]) => {
-      return `  - ${disk}: ${utilization}%`;
-    })
+    .map(([disk, utilization]) => `  - *${disk}*: *${utilization}%*`)
     .join("\n");
 
-  return `Average host metrics within epoch ${epoch}:\n
-- CPU temperature: ${avgCpuTemperature}°C
-- CPU usage: ${avgCpuUsage}%
-- Memory usage: ${avgMemoryUsage}%
-- Disk I/O utilization:\n${ioUtilizationPerDiskMessage}\n\n
+  // Create a structured and formatted message
+  return `⚠️ *Average host metrics within epoch ${epoch}*:\n
+- *CPU temperature*: *${avgCpuTemperature}°C*
+- *CPU usage*: *${avgCpuUsage}%*
+- *Memory usage*: *${avgMemoryUsage}%*
+- *Disk I/O utilization*:\n${ioUtilizationPerDiskMessage}\n
 ${getDmsDashboardsMessage({ startTimestamp, endTimestamp })}`;
 }
 
@@ -141,11 +140,10 @@ function getDmsDashboardsMessage({
   startTimestamp: number;
   endTimestamp: number;
 }): string {
-  // dashboard links must be with timestamps in milliseconds
-  // see https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/manage-dashboard-links/
   const startTimestampInMs = startTimestamp * 1000;
   const endTimestampInMs = endTimestamp * 1000;
-  return `For more details, check the DMS dashboards:\n
+
+  return `🔗 *For more details, check the DMS dashboards:*\n
 - [Host dashboard](http://dms.dappnode/d/dms-host/host?orgId=1&from=${startTimestampInMs}&to=${endTimestampInMs})
 - [Docker dashboard](http://dms.dappnode/d/dms-docker/docker?orgId=1&from=${startTimestampInMs}&to=${endTimestampInMs})`;
 }

--- a/packages/brain/src/modules/cron/trackValidatorsPerformance/sendValidatorsPerformanceNotifications.ts
+++ b/packages/brain/src/modules/cron/trackValidatorsPerformance/sendValidatorsPerformanceNotifications.ts
@@ -126,11 +126,11 @@ async function getHostMetricsMessage(prometheusApi: PrometheusApi, epoch: string
     })
     .join("\n");
 
-  return `Host metrics:
+  return `Average host metrics within epoch ${epoch}:\n
 - CPU temperature: ${avgCpuTemperature}°C
 - CPU usage: ${avgCpuUsage}%
 - Memory usage: ${avgMemoryUsage}%
-- Disk I/O utilization:\n${ioUtilizationPerDiskMessage}
+- Disk I/O utilization:\n${ioUtilizationPerDiskMessage}\n
 ${getDmsDashboardsMessage({ startTimestamp, endTimestamp })}`;
 }
 
@@ -141,7 +141,7 @@ function getDmsDashboardsMessage({
   startTimestamp: number;
   endTimestamp: number;
 }): string {
-  return `For more details, check the DMS dashboards:
+  return `For more details, check the DMS dashboards:\n
 - [Host dashboard](http://dms.dappnode/d/dms-host/host?orgId=1&from=${startTimestamp}&to=${endTimestamp})
 - [Docker dashboard](http://dms.dappnode/d/dms-docker/docker?orgId=1&from=${startTimestamp}&to=${endTimestamp})`;
 }

--- a/packages/brain/src/modules/cron/trackValidatorsPerformance/sendValidatorsPerformanceNotifications.ts
+++ b/packages/brain/src/modules/cron/trackValidatorsPerformance/sendValidatorsPerformanceNotifications.ts
@@ -122,7 +122,7 @@ async function getHostMetricsMessage(prometheusApi: PrometheusApi, epoch: string
   // create beautiful message for ioUtilizationPerDisk
   const ioUtilizationPerDiskMessage = Object.entries(ioUtilizationPerDisk)
     .map(([disk, utilization]) => {
-      return `  - ${disk}: ${utilization}%\n`;
+      return `  - ${disk}: ${utilization}%`;
     })
     .join("\n");
 
@@ -130,7 +130,7 @@ async function getHostMetricsMessage(prometheusApi: PrometheusApi, epoch: string
 - CPU temperature: ${avgCpuTemperature}°C
 - CPU usage: ${avgCpuUsage}%
 - Memory usage: ${avgMemoryUsage}%
-- Disk I/O utilization:\n${ioUtilizationPerDiskMessage}\n
+- Disk I/O utilization:\n${ioUtilizationPerDiskMessage}\n\n
 ${getDmsDashboardsMessage({ startTimestamp, endTimestamp })}`;
 }
 

--- a/packages/brain/test/unit/modules/apiClients/prometheus.unit.test.ts
+++ b/packages/brain/test/unit/modules/apiClients/prometheus.unit.test.ts
@@ -1,0 +1,17 @@
+import { Network } from "@stakingbrain/common";
+import { PrometheusApi } from "../../../../src/modules/apiClients/index.js";
+
+describe.skip("Prometheus API", () => {
+  const prometheusApi = new PrometheusApi({
+    baseUrl: "http://prometheus.dms.dappnode:9090",
+    minGenesisTime: 1695902100,
+    secondsPerSlot: 12,
+    slotsPerEpoch: 32,
+    network: Network.Holesky
+  });
+
+  it("should get prometheus metrics", async () => {
+    const metrics = await prometheusApi.getPrometheusMetrics({ epoch: 83660 });
+    console.log(metrics);
+  });
+});


### PR DESCRIPTION
Add prometheus client and collect host metrics for notifications:
- warning: validator missed attstation
- danger: validator missed proposing a block

The host metrics are collected 
- Average CPU temp
- Average CPU usage
- Average memory usage
- Disk IO utilization