### PR TITLE
Add brain API 

### DIFF
--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -11,7 +11,7 @@ import {
   PostgresClient,
   PrometheusApi
 } from "./modules/apiClients/index.js";
-import { startUiServer, startLaunchpadApi } from "./modules/apiServers/index.js";
+import { startUiServer, startLaunchpadApi, startBrainApi } from "./modules/apiServers/index.js";
 import * as dotenv from "dotenv";
 import process from "node:process";
 import { params } from "./params.js";
@@ -99,6 +99,7 @@ export const postgresClient = new PostgresClient(postgresUrl);
 // Start server APIs
 const uiServer = startUiServer(path.resolve(__dirname, params.uiBuildDirName), network);
 const launchpadServer = startLaunchpadApi();
+const brainApiServer = startBrainApi();
 
 await brainDb.initialize(signerApi, validatorApi);
 logger.debug(brainDb.data);
@@ -141,6 +142,7 @@ function handle(signal: string): void {
   postgresClient.close().catch((err) => logger.error(`Error closing postgres client`, err)); // postgresClient db connection is the only external resource that needs to be closed
   uiServer.close();
   launchpadServer.close();
+  brainApiServer.close();
   logger.debug(`Stopped all cron jobs and closed all connections.`);
   process.exit(0);
 }

--- a/packages/brain/src/modules/apiServers/brain/config.ts
+++ b/packages/brain/src/modules/apiServers/brain/config.ts
@@ -1,0 +1,3 @@
+export const corsOptions = {
+  origin: ["http://csm-lido.dappnode", "http://csm-lido.testnet.dappnode"] // TODO: update with DAppNodePackage-lido-csm.dnp.dappnode.eth domains
+};

--- a/packages/brain/src/modules/apiServers/brain/index.ts
+++ b/packages/brain/src/modules/apiServers/brain/index.ts
@@ -1,0 +1,1 @@
+export { startBrainApi } from "./startBrainApi.js";

--- a/packages/brain/src/modules/apiServers/brain/routes/index.ts
+++ b/packages/brain/src/modules/apiServers/brain/routes/index.ts
@@ -1,0 +1,1 @@
+export * from "./validators/index.js";

--- a/packages/brain/src/modules/apiServers/brain/routes/validators/index.ts
+++ b/packages/brain/src/modules/apiServers/brain/routes/validators/index.ts
@@ -1,0 +1,3 @@
+import validatorsRouter from "./route.js";
+
+export { validatorsRouter };

--- a/packages/brain/src/modules/apiServers/brain/routes/validators/route.ts
+++ b/packages/brain/src/modules/apiServers/brain/routes/validators/route.ts
@@ -1,0 +1,50 @@
+import { Tag } from "@stakingbrain/common";
+import express from "express";
+import { getAndValidateQueryParameters } from "./validation.js";
+import logger from "../../../../logger/index.js";
+import { brainDb } from "../../../../../index.js";
+
+const validatorsRouter = express.Router();
+
+const validatorsEndpoint = "/api/v0/brain/validators";
+
+validatorsRouter.get(validatorsEndpoint, async (req, res) => {
+  const result = getAndValidateQueryParameters(req.query);
+  if (result instanceof Error) {
+    res.status(400).send({ message: `Bad request: ${result}` });
+    return;
+  }
+
+  const { format, tag } = result;
+
+  try {
+    const validators = brainDb.getData();
+
+    const tagValidatorsMap = new Map<Tag, string[]>();
+
+    for (const [pubkey, details] of Object.entries(validators)) {
+      if (!tag?.includes(details.tag)) continue;
+
+      const tagList = tagValidatorsMap.get(details.tag) || [];
+
+      if (format === "index") {
+        if (!details.index) {
+          res.status(404).send({
+            message: `Validator index not found for validator ${pubkey}. It might be not active. Consider using format pubkey`
+          });
+          return;
+        }
+        tagList.push(details.index.toString());
+      } else tagList.push(pubkey);
+
+      tagValidatorsMap.set(details.tag, tagList);
+    }
+
+    res.send(Object.fromEntries(tagValidatorsMap));
+  } catch (e) {
+    logger.error(e);
+    res.status(500).send({ message: "Internal server error" });
+  }
+});
+
+export default validatorsRouter;

--- a/packages/brain/src/modules/apiServers/brain/routes/validators/validation.ts
+++ b/packages/brain/src/modules/apiServers/brain/routes/validators/validation.ts
@@ -1,0 +1,40 @@
+// import from express querystring
+import { Tag, tags } from "@stakingbrain/common";
+import QueryString from "qs";
+
+export function getAndValidateQueryParameters(requestQuery: QueryString.ParsedQs):
+  | {
+      format: "pubkey" | "index";
+      tag?: Tag[];
+    }
+  | Error {
+  const { tag, format } = requestQuery;
+  try {
+    return {
+      format: getAndValidateFormat(format),
+      tag: getAndValidateTag(tag)
+    };
+  } catch (e) {
+    return e;
+  }
+}
+
+function getAndValidateFormat(
+  format: string | QueryString.ParsedQs | string[] | QueryString.ParsedQs[] | undefined
+): "pubkey" | "index" {
+  if (!format) throw Error("format is required");
+  if (format !== "pubkey" && format !== "index") throw Error("format must be pubkey or index");
+  return format as "pubkey" | "index";
+}
+
+function getAndValidateTag(tag: string | QueryString.ParsedQs | string[] | QueryString.ParsedQs[] | undefined): Tag[] {
+  if (!tag) return [];
+  if (typeof tag === "string") {
+    if (!tags.includes(tag as Tag)) throw Error("Invalid tag");
+    return [tag as Tag];
+  } else {
+    if (!Array.isArray(tag)) throw Error("tag must be an array");
+    for (const t of tag) if (!tags.includes(t as Tag)) throw Error("Invalid tag");
+    return tag as Tag[];
+  }
+}

--- a/packages/brain/src/modules/apiServers/brain/startBrainApi.ts
+++ b/packages/brain/src/modules/apiServers/brain/startBrainApi.ts
@@ -1,0 +1,22 @@
+import express from "express";
+import cors from "cors";
+import logger from "../../logger/index.js";
+import http from "node:http";
+import { params } from "../../../params.js";
+import { corsOptions } from "./config.js";
+import { validatorsRouter } from "./routes/index.js";
+
+export function startBrainApi(): http.Server {
+  const app = express();
+  app.use(express.json());
+  app.use(cors(corsOptions));
+
+  app.use(validatorsRouter);
+
+  const server = new http.Server(app);
+  server.listen(params.brainPort, () => {
+    logger.info(`Brain API listening on port ${params.brainPort}`);
+  });
+
+  return server;
+}

--- a/packages/brain/src/modules/apiServers/index.ts
+++ b/packages/brain/src/modules/apiServers/index.ts
@@ -1,2 +1,3 @@
 export * from "./ui/index.js";
 export * from "./launchpad/index.js";
+export * from "./brain/index.js";

--- a/packages/brain/src/modules/db/types.ts
+++ b/packages/brain/src/modules/db/types.ts
@@ -1,3 +1,5 @@
+import { Tag } from "@stakingbrain/common";
+
 /**
  * DbSlot represents the line in the database for a given public key:
  * @param pubkey - the public key
@@ -25,13 +27,6 @@ export interface PubkeyDetails {
   index?: number; // index of the validator. Only available if the validator is active.
 }
 
-export const tags = ["obol", "diva", "ssv", "rocketpool", "stakewise", "stakehouse", "solo", "stader", "lido"] as const;
-
 export const nonEditableFeeRecipientTags = ["rocketpool", "stader", "stakewise", "lido"] as const;
 
 export type NonEditableFeeRecipientTag = (typeof nonEditableFeeRecipientTags)[number];
-
-/**
- * Tag describes the protocol of the public key imported
- */
-export type Tag = (typeof tags)[number];

--- a/packages/brain/src/params.ts
+++ b/packages/brain/src/params.ts
@@ -8,6 +8,7 @@ export const params = {
   defaultTag: "solo" as Tag,
   uiPort: 80,
   launchpadPort: 3000,
+  brainPort: 5000,
   defaultValidatorsMonitorUrl: "https://validators-proofs.dappnode.io",
   defaultProofsOfValidationCron: 24 * 60 * 60 * 1000 // 1 day in ms
 };


### PR DESCRIPTION
Add brain API  for querying validators associated a tags/protocols. 

**API spec:** 

GET `/api/v0/brain/validators?tag=lido&tag=lido&format=pubkey`: get validators loaded in brain.
- tag (optional): string comma separated of "obol", "diva", "ssv", "rocketpool", "stakewise", "stakehouse", "solo", "stader", "lido". If not provided will be retrived from all tags
- format (required): one of "pubkey" | "index"

Response example

```json
{
    "solo": ["validatorPubkey1", "validatorPubkey2"],
    "lido": ["validatorPubkey3", "validatorPubkey4"]
}
```
