### PR TITLE
Lido csm pkg dns for cors

### DIFF
--- a/packages/brain/src/modules/apiServers/launchpad/config.ts
+++ b/packages/brain/src/modules/apiServers/launchpad/config.ts
@@ -3,6 +3,8 @@ export const corsOptions = {
     "http://rocketpool-testnet.public.dappnode",
     "http://rocketpool.dappnode",
     "http://stader-testnet.dappnode",
-    "http://stader.dappnode"
+    "http://stader.dappnode",
+    "http://ui.lido-csm-holesky.dappnode",
+    "http://ui.lido-csm-mainnet.dappnode"
   ]
 };


### PR DESCRIPTION
Adding holesky and mainnet lido csm package UI's  DNS in order to  avoid CORS restrictions when importing validators to brain.